### PR TITLE
Domino 5.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
                 <version>7.2.0</version>
                 <executions>
                     <execution>
+                        <id>domino-v4-endpoints</id>
                         <goals>
                             <goal>generate</goal>
                         </goals>
@@ -139,6 +140,30 @@
                             <apiPackage>com.dominodatalab.api.rest</apiPackage>
                             <modelPackage>com.dominodatalab.api.model</modelPackage>
                             <invokerPackage>com.dominodatalab.api.invoker</invokerPackage>
+                            <generateSupportingFiles>true</generateSupportingFiles>
+                            <generateModelTests>false</generateModelTests>
+                            <generateApiTests>false</generateApiTests>
+                            <configOptions>
+                                <serializableModel>false</serializableModel>
+                                <dateLibrary>java8</dateLibrary>
+                                <openApiNullable>false</openApiNullable>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>domino-public-endpoints</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/conf/domino-public-api.json</inputSpec>
+                            <skipValidateSpec>true</skipValidateSpec>
+                            <skipIfSpecIsUnchanged>true</skipIfSpecIsUnchanged>
+                            <generatorName>java</generatorName>
+                            <library>native</library>
+                            <apiPackage>com.dominodatalab.public.rest</apiPackage>
+                            <modelPackage>com.dominodatalab.public.model</modelPackage>
+                            <invokerPackage>com.dominodatalab.public.invoker</invokerPackage>
                             <generateSupportingFiles>true</generateSupportingFiles>
                             <generateModelTests>false</generateModelTests>
                             <generateApiTests>false</generateApiTests>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.ksmpartners</groupId>
     <artifactId>domino-java-client</artifactId>
     <packaging>jar</packaging>
-    <version>5.7.2</version>
+    <version>5.9.1.0</version>
     <name>Domino Data Lab API Client</name>
     <description>Domino Data Lab API Client to connect to Domino web services using Java HTTP Client.</description>
     <url>https://github.com/ksmpartners/domino-java-client</url>

--- a/pom.xml
+++ b/pom.xml
@@ -161,9 +161,9 @@
                             <skipIfSpecIsUnchanged>true</skipIfSpecIsUnchanged>
                             <generatorName>java</generatorName>
                             <library>native</library>
-                            <apiPackage>com.dominodatalab.public.rest</apiPackage>
-                            <modelPackage>com.dominodatalab.public.model</modelPackage>
-                            <invokerPackage>com.dominodatalab.public.invoker</invokerPackage>
+                            <apiPackage>com.dominodatalab.pub.rest</apiPackage>
+                            <modelPackage>com.dominodatalab.pub.model</modelPackage>
+                            <invokerPackage>com.dominodatalab.pub.invoker</invokerPackage>
                             <generateSupportingFiles>true</generateSupportingFiles>
                             <generateModelTests>false</generateModelTests>
                             <generateApiTests>false</generateApiTests>

--- a/src/conf/domino-openapi.json
+++ b/src/conf/domino-openapi.json
@@ -30741,6 +30741,7 @@
             "name": "path",
             "required": false,
             "schema": {
+              "nullable": true,
               "type": "string"
             }
           }

--- a/src/conf/domino-openapi.json
+++ b/src/conf/domino-openapi.json
@@ -31,16 +31,6 @@
         },
         "description": "An internal error prevented the server from performing this action"
       },
-      "ModelProductErrorResponse": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
-            }
-          }
-        },
-        "description": ""
-      },
       "NotFound": {
         "content": {
           "application/json": {
@@ -115,6 +105,19 @@
           "Ray",
           "Dask",
           "MPI"
+        ],
+        "type": "string"
+      },
+      "DocumentType": {
+        "description": "List of searchable document types",
+        "enum": [
+          "project",
+          "file",
+          "run",
+          "model",
+          "environment",
+          "comment",
+          "dataset"
         ],
         "type": "string"
       },
@@ -323,24 +326,32 @@
             "enum": [
               "MODEL_API_STATUS_CHANGE",
               "PROJECT_GOAL_MODEL_LINK_CHANGE",
+              "MODEL_REVIEW_CREATED",
               "JOB_STATUS_CHANGE",
               "WORKSPACE_TITLE_CHANGE",
               "PROJECT_STATUS_CHANGE",
-              "PROJECT_GOAL_CREATE",
               "APP_STATUS_CHANGE",
               "FILE_CHANGE",
               "PROJECT_GOAL_APP_LINK_CHANGE",
               "SCHEDULE_JOB_CONFIG_CHANGE",
+              "PROJECT_GOAL_STAGE_CHANGE",
+              "ALL_MODEL_REVIEWERS_APPROVED",
               "JOB_TITLE_CHANGE",
               "PROJECT_GOAL_TITLE_CHANGE",
               "COMMENT_UPDATED",
+              "MODEL_REVIEWER_APPROVED",
+              "MODEL_REVIEW_CANCELLED",
               "PROJECT_GOAL_DESCRIPTION_CHANGE",
               "PROJECT_STAGE_CHANGE",
               "COMMENT_ADDED",
+              "PROJECT_GOAL_ASSIGNMENT_CHANGE",
+              "PROJECT_GOAL_CREATE",
               "SCHEDULE_JOB_TRIGGER_CHANGE",
               "PROJECT_LINK_CHANGE",
               "PROJECT_GOAL_FILE_LINK_CHANGE",
               "PROJECT_GOAL_STATUS_CHANGE",
+              "REGISTERED_MODEL_STAGE_TRANSITIONED",
+              "MODEL_REVIEWER_REQUESTED_CHANGES",
               "PROJECT_GOAL_JOB_LINK_CHANGE",
               "COMMENT_ARCHIVED",
               "WORKSPACE_STATUS_CHANGE",
@@ -357,11 +368,13 @@
               "project",
               "job",
               "model_api",
-              "workspace",
               "comment",
               "app",
+              "goals",
               "schedule_job",
-              "files"
+              "files",
+              "workspace",
+              "registered_model"
             ],
             "type": "string"
           },
@@ -380,7 +393,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -415,7 +428,7 @@
       "domino.activity.api.ActivityPagination": {
         "properties": {
           "latestTimeStamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "pageSize": {
@@ -447,6 +460,9 @@
       },
       "domino.activity.api.AllMetadata": {
         "properties": {
+          "allModelReviewersApprovedMetadata": {
+            "$ref": "#/components/schemas/domino.activity.api.AllModelReviewersApprovedMetadata"
+          },
           "appStatusActivityMetaData": {
             "$ref": "#/components/schemas/domino.activity.api.AppStatusActivityMetaData"
           },
@@ -471,11 +487,17 @@
           "jobStatusActivityMetaData": {
             "$ref": "#/components/schemas/domino.activity.api.JobStatusActivityMetaData"
           },
+          "modelReviewActivityWithNotesMetadata": {
+            "$ref": "#/components/schemas/domino.activity.api.ModelReviewActivityWithNotesMetadata"
+          },
           "modelVersionStatusActivityMetaData": {
             "$ref": "#/components/schemas/domino.activity.api.ModelVersionStatusActivityMetaData"
           },
           "projectGoalAppLinkActivityMetadata": {
             "$ref": "#/components/schemas/domino.activity.api.ProjectGoalAppLinkActivityMetadata"
+          },
+          "projectGoalAssignmentChangeActivityMetadata": {
+            "$ref": "#/components/schemas/domino.activity.api.ProjectGoalAssignmentChangeActivityMetadata"
           },
           "projectGoalCreateActivityMetadata": {
             "$ref": "#/components/schemas/domino.activity.api.ProjectGoalCreateActivityMetadata"
@@ -488,6 +510,9 @@
           },
           "projectGoalModelLinkActivityMetadata": {
             "$ref": "#/components/schemas/domino.activity.api.ProjectGoalModelLinkActivityMetadata"
+          },
+          "projectGoalStageChangeActivityMetaData": {
+            "$ref": "#/components/schemas/domino.activity.api.ProjectGoalStageChangeActivityMetadata"
           },
           "projectGoalStatusChangeActivityMetadata": {
             "$ref": "#/components/schemas/domino.activity.api.ProjectGoalStatusChangeActivityMetadata"
@@ -509,6 +534,9 @@
           },
           "projectStatusChangeActivityMetaData": {
             "$ref": "#/components/schemas/domino.activity.api.ProjectStatusChangeActivityMetaData"
+          },
+          "registeredModelStageTransitionedMetadata": {
+            "$ref": "#/components/schemas/domino.activity.api.RegisteredModelStageTransitionedMetadata"
           },
           "scheduleJobActivityMetaData": {
             "$ref": "#/components/schemas/domino.activity.api.ScheduleJobActivityMetaData"
@@ -537,6 +565,8 @@
           "fileChangeActivityMetaData",
           "projectGoalCreateActivityMetadata",
           "projectGoalStatusChangeActivityMetadata",
+          "projectGoalStageChangeActivityMetaData",
+          "projectGoalAssignmentChangeActivityMetadata",
           "projectGoalUpdateTitleActivityMetadata",
           "projectGoalUpdateDescriptionActivityMetadata",
           "projectGoalFileLinkActivityMetadata",
@@ -544,7 +574,33 @@
           "projectGoalWorkspaceLinkActivityMetadata",
           "projectGoalAppLinkActivityMetadata",
           "projectGoalModelLinkActivityMetadata",
-          "projectLinkChangeActivityMetadata"
+          "projectLinkChangeActivityMetadata",
+          "modelReviewActivityWithNotesMetadata",
+          "allModelReviewersApprovedMetadata",
+          "registeredModelStageTransitionedMetadata"
+        ]
+      },
+      "domino.activity.api.AllModelReviewersApprovedMetadata": {
+        "properties": {
+          "initialStage": {
+            "type": "string"
+          },
+          "modelVersion": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "reviewId": {
+            "type": "string"
+          },
+          "targetStage": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "modelVersion",
+          "initialStage",
+          "targetStage",
+          "reviewId"
         ]
       },
       "domino.activity.api.AppStatusActivityMetaData": {
@@ -762,6 +818,33 @@
           "commentCount"
         ]
       },
+      "domino.activity.api.ModelReviewActivityWithNotesMetadata": {
+        "properties": {
+          "initialStage": {
+            "type": "string"
+          },
+          "modelVersion": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "reviewId": {
+            "type": "string"
+          },
+          "targetStage": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "modelVersion",
+          "initialStage",
+          "targetStage",
+          "reviewId",
+          "notes"
+        ]
+      },
       "domino.activity.api.ModelVersionStatusActivityMetaData": {
         "properties": {
           "action": {
@@ -824,6 +907,20 @@
           "appVersionId",
           "projectGoalTitle",
           "name"
+        ]
+      },
+      "domino.activity.api.ProjectGoalAssignmentChangeActivityMetadata": {
+        "properties": {
+          "assignee": {
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
         ]
       },
       "domino.activity.api.ProjectGoalCreateActivityMetadata": {
@@ -931,12 +1028,38 @@
           "name"
         ]
       },
+      "domino.activity.api.ProjectGoalStageChangeActivityMetadata": {
+        "properties": {
+          "fromStage": {
+            "$ref": "#/components/schemas/domino.activity.api.ProjectStage"
+          },
+          "title": {
+            "type": "string"
+          },
+          "toStage": {
+            "$ref": "#/components/schemas/domino.activity.api.ProjectStage"
+          }
+        },
+        "required": [
+          "fromStage",
+          "toStage",
+          "title"
+        ]
+      },
       "domino.activity.api.ProjectGoalStatusChangeActivityMetadata": {
         "properties": {
+          "fromStatus": {
+            "enum": [
+              "complete",
+              "incomplete",
+              "delete"
+            ],
+            "type": "string"
+          },
           "projectGoalTitle": {
             "type": "string"
           },
-          "statusChange": {
+          "toStatus": {
             "enum": [
               "complete",
               "incomplete",
@@ -946,7 +1069,8 @@
           }
         },
         "required": [
-          "statusChange",
+          "fromStatus",
+          "toStatus",
           "projectGoalTitle"
         ]
       },
@@ -1111,6 +1235,25 @@
           "projectName",
           "fromStatus",
           "toStatus"
+        ]
+      },
+      "domino.activity.api.RegisteredModelStageTransitionedMetadata": {
+        "properties": {
+          "initialStage": {
+            "type": "string"
+          },
+          "modelVersion": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "targetStage": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "modelVersion",
+          "initialStage",
+          "targetStage"
         ]
       },
       "domino.activity.api.ScheduleJobActivityMetaData": {
@@ -1434,6 +1577,42 @@
           "diskUtilization"
         ]
       },
+      "domino.admin.interface.ConfigSettingDto": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "nameMaybe": {
+            "nullable": true,
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "namespace",
+          "key",
+          "value"
+        ]
+      },
+      "domino.admin.interface.ConfigSettingEntityDto": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "setting": {
+            "$ref": "#/components/schemas/domino.admin.interface.ConfigSettingDto"
+          }
+        },
+        "required": [
+          "id",
+          "setting"
+        ]
+      },
       "domino.admin.interface.ExecutionOverview": {
         "properties": {
           "computeClusterOverviews": {
@@ -1677,6 +1856,13 @@
           "appName": {
             "type": "string"
           },
+          "appURL": {
+            "type": "string"
+          },
+          "colorTheme": {
+            "nullable": true,
+            "type": "string"
+          },
           "defaultProjectName": {
             "type": "string"
           },
@@ -1691,6 +1877,9 @@
           },
           "helpContentUrl": {
             "type": "string"
+          },
+          "hideAddProjectAction": {
+            "type": "boolean"
           },
           "hideDownloadDominoCli": {
             "type": "boolean"
@@ -1724,14 +1913,20 @@
           },
           "supportEmail": {
             "type": "string"
+          },
+          "supportUrl": {
+            "type": "string"
           }
         },
         "required": [
+          "appURL",
           "errorPageContactEmail",
           "defaultProjectName",
           "favicon",
           "gitCredentialsDescription",
           "helpContentUrl",
+          "supportUrl",
+          "hideAddProjectAction",
           "hidePopularProjects",
           "hideDownloadDominoCli",
           "hideMarketingDisclaimer",
@@ -1754,6 +1949,16 @@
           }
         },
         "type": "object"
+      },
+      "domino.common.DominoId": {
+        "properties": {
+          "raw": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "raw"
+        ]
       },
       "domino.common.ProjectId": {
         "properties": {
@@ -1943,6 +2148,20 @@
           "totalCostAmount"
         ]
       },
+      "domino.common.gateway.search.CollaboratorDetails": {
+        "properties": {
+          "highlightedUsername": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "highlightedUsername"
+        ]
+      },
       "domino.common.gateway.search.EntityHighlight": {
         "properties": {
           "entityName": {
@@ -2083,6 +2302,274 @@
           "maybeHighlightedModelAuthor"
         ]
       },
+      "domino.common.gateway.search.SearchCommentDTO": {
+        "properties": {
+          "contextDescription": {
+            "type": "string"
+          },
+          "offset": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "project": {
+            "$ref": "#/components/schemas/domino.common.gateway.search.SearchProjectDetails"
+          }
+        },
+        "required": [
+          "project",
+          "contextDescription",
+          "offset"
+        ]
+      },
+      "domino.common.gateway.search.SearchDatasetDTO": {
+        "properties": {
+          "authorName": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/domino.common.gateway.search.SearchProjectDetails"
+          },
+          "status": {
+            "type": "string"
+          },
+          "tagNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "description",
+          "authorName",
+          "status",
+          "created",
+          "project",
+          "tagNames"
+        ]
+      },
+      "domino.common.gateway.search.SearchEnvironmentDTO": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "dockerfile": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "visibility",
+          "dockerfile"
+        ]
+      },
+      "domino.common.gateway.search.SearchFileDTO": {
+        "properties": {
+          "codeSnippet": {
+            "nullable": true,
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/domino.common.gateway.search.SearchProjectDetails"
+          }
+        },
+        "required": [
+          "project"
+        ]
+      },
+      "domino.common.gateway.search.SearchModelDTO": {
+        "properties": {
+          "collaborators": {
+            "items": {
+              "$ref": "#/components/schemas/domino.common.gateway.search.CollaboratorDetails"
+            },
+            "type": "array"
+          },
+          "environmentLink": {
+            "type": "string"
+          },
+          "environmentName": {
+            "type": "string"
+          },
+          "projects": {
+            "items": {
+              "$ref": "#/components/schemas/domino.common.gateway.search.SearchProjectDetails"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "environmentName",
+          "environmentLink",
+          "projects",
+          "collaborators"
+        ]
+      },
+      "domino.common.gateway.search.SearchPageGatewayDTO": {
+        "properties": {
+          "hasMoreResults": {
+            "type": "boolean"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/domino.common.gateway.search.SearchPageResultGatewayDTO"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "results",
+          "hasMoreResults"
+        ]
+      },
+      "domino.common.gateway.search.SearchPageResultGatewayDTO": {
+        "properties": {
+          "area": {
+            "type": "string"
+          },
+          "commentInfo": {
+            "$ref": "#/components/schemas/domino.common.gateway.search.SearchCommentDTO",
+            "nullable": true
+          },
+          "datasetInfo": {
+            "$ref": "#/components/schemas/domino.common.gateway.search.SearchDatasetDTO",
+            "nullable": true
+          },
+          "displayText": {
+            "nullable": true,
+            "type": "string"
+          },
+          "environmentInfo": {
+            "$ref": "#/components/schemas/domino.common.gateway.search.SearchEnvironmentDTO",
+            "nullable": true
+          },
+          "featureViewInfo": {
+            "$ref": "#/components/schemas/domino.common.gateway.search.FeatureViewSearchResultDTO",
+            "nullable": true
+          },
+          "fileInfo": {
+            "$ref": "#/components/schemas/domino.common.gateway.search.SearchFileDTO",
+            "nullable": true
+          },
+          "id": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "link": {
+            "type": "string"
+          },
+          "modelInfo": {
+            "$ref": "#/components/schemas/domino.common.gateway.search.SearchModelDTO",
+            "nullable": true
+          },
+          "ownerId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "path": {
+            "nullable": true,
+            "type": "string"
+          },
+          "projectId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "projectInfo": {
+            "$ref": "#/components/schemas/domino.common.gateway.search.SearchProjectDTO",
+            "nullable": true
+          },
+          "runInfo": {
+            "$ref": "#/components/schemas/domino.common.gateway.search.SearchRunDTO",
+            "nullable": true
+          }
+        },
+        "required": [
+          "link",
+          "area"
+        ]
+      },
+      "domino.common.gateway.search.SearchProjectDTO": {
+        "properties": {
+          "blockerReason": {
+            "nullable": true,
+            "type": "string"
+          },
+          "goal": {
+            "nullable": true,
+            "type": "string"
+          },
+          "goalLink": {
+            "type": "string"
+          },
+          "isRestricted": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/domino.common.gateway.search.SearchProjectTag"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "snippet",
+          "tags",
+          "goalLink"
+        ]
+      },
+      "domino.common.gateway.search.SearchProjectDetails": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "projectLink": {
+            "type": "string"
+          },
+          "projectName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "projectName",
+          "projectLink"
+        ]
+      },
+      "domino.common.gateway.search.SearchProjectTag": {
+        "properties": {
+          "id": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "isApproved": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "isApproved"
+        ]
+      },
       "domino.common.gateway.search.SearchResultGatewayDTO": {
         "properties": {
           "area": {
@@ -2122,6 +2609,44 @@
         "required": [
           "link",
           "area"
+        ]
+      },
+      "domino.common.gateway.search.SearchRunDTO": {
+        "properties": {
+          "command": {
+            "type": "string"
+          },
+          "completed": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "string"
+          },
+          "jobLink": {
+            "type": "string"
+          },
+          "ownerName": {
+            "type": "string"
+          },
+          "projectName": {
+            "type": "string"
+          },
+          "resultLink": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "command",
+          "status",
+          "completed",
+          "duration",
+          "ownerName",
+          "projectName",
+          "jobLink",
+          "resultLink"
         ]
       },
       "domino.common.gateway.search.TagKeyHighlight": {
@@ -2241,7 +2766,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -2281,7 +2806,7 @@
             "$ref": "#/components/schemas/domino.common.modelproduct.AppResourceUsage"
           },
           "started": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "status": {
@@ -2324,7 +2849,7 @@
             "type": "string"
           },
           "started": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "status": {
@@ -2406,7 +2931,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -2813,6 +3338,16 @@
           "stateMap"
         ]
       },
+      "domino.common.util.yaml.DefaultYamlString": {
+        "properties": {
+          "raw": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "raw"
+        ]
+      },
       "domino.computecluster.api.ComputeClusterConfig": {
         "properties": {
           "clusterType": {
@@ -3145,52 +3680,6 @@
           "workerCount"
         ]
       },
-      "domino.computegrid.ExecutionCheckpoint": {
-        "properties": {
-          "checkpointName": {
-            "enum": [
-              "UserFilesSaved",
-              "ResourcesCreated",
-              "NodeAssigned",
-              "VolumesMounted",
-              "ResourcesDeleted",
-              "QuotaChecked",
-              "VolumesReleased",
-              "UserCodeLaunched",
-              "FilesPrepared",
-              "Acknowledged",
-              "ImagesPulled"
-            ],
-            "type": "string"
-          },
-          "completedTimestamp": {
-            "format": "date-time",
-            "nullable": true,
-            "type": "string"
-          },
-          "message": {
-            "nullable": true,
-            "type": "string"
-          },
-          "status": {
-            "enum": [
-              "Pending",
-              "Completed",
-              "Error"
-            ],
-            "type": "string"
-          },
-          "timeSpentMillis": {
-            "format": "int64",
-            "nullable": true,
-            "type": "integer"
-          }
-        },
-        "required": [
-          "checkpointName",
-          "status"
-        ]
-      },
       "domino.computegrid.ExecutionEventDto": {
         "properties": {
           "attempt": {
@@ -3385,7 +3874,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -3415,6 +3904,150 @@
           "logContent",
           "isComplete",
           "pagination"
+        ]
+      },
+      "domino.computegrid.MonitoredExecutionResource": {
+        "properties": {
+          "debugText": {
+            "nullable": true,
+            "type": "string"
+          },
+          "extraInfo": {
+            "nullable": true,
+            "type": "play.api.libs.json.jsvalue"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "helpText": {
+            "nullable": true,
+            "type": "string"
+          },
+          "lastEventTimestamp": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "startupStatus": {
+            "enum": [
+              "READY",
+              "IN_PROGRESS",
+              "WARNING",
+              "UNKNOWN"
+            ],
+            "type": "string"
+          },
+          "startupStatusMessage": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "shortName",
+          "fullName",
+          "startupStatus",
+          "startupStatusMessage"
+        ]
+      },
+      "domino.computegrid.MonitoredExecutionResourceList": {
+        "properties": {
+          "combinedResourceStatus": {
+            "enum": [
+              "READY",
+              "IN_PROGRESS",
+              "WARNING",
+              "UNKNOWN"
+            ],
+            "type": "string"
+          },
+          "resourcePluralName": {
+            "type": "string"
+          },
+          "resourceSingularName": {
+            "type": "string"
+          },
+          "resources": {
+            "items": {
+              "$ref": "#/components/schemas/domino.computegrid.MonitoredExecutionResource"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "resourcePluralName",
+          "resourceSingularName",
+          "resources",
+          "combinedResourceStatus"
+        ]
+      },
+      "domino.computegrid.MonitoredResourceExecutionCheckpoint": {
+        "properties": {
+          "checkpointName": {
+            "enum": [
+              "UserFilesSaved",
+              "ResourcesCreated",
+              "NodeAssigned",
+              "VolumesMounted",
+              "ResourcesDeleted",
+              "QuotaChecked",
+              "ExecutionAvailable",
+              "VolumesReleased",
+              "UserCodeLaunched",
+              "FilesPrepared",
+              "Acknowledged",
+              "ImagesPulled"
+            ],
+            "type": "string"
+          },
+          "combinedResourceStatus": {
+            "enum": [
+              "READY",
+              "IN_PROGRESS",
+              "WARNING",
+              "UNKNOWN"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "completedTimestamp": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "message": {
+            "nullable": true,
+            "type": "string"
+          },
+          "resources": {
+            "items": {
+              "$ref": "#/components/schemas/domino.computegrid.MonitoredExecutionResourceList"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "startupTip": {
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "Pending",
+              "Completed",
+              "Error"
+            ],
+            "type": "string"
+          },
+          "timeSpentMillis": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "checkpointName",
+          "status"
         ]
       },
       "domino.computegrid.PaginationFilter": {
@@ -3461,7 +4094,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -3483,6 +4116,7 @@
               "AWSIAMRole",
               "AWSIAMRoleWithUsername",
               "OAuth",
+              "PersonalToken",
               "UserOnly",
               "BasicOptional",
               "NoAuth",
@@ -3649,6 +4283,13 @@
             },
             "type": "array"
           },
+          "projectsInfo": {
+            "items": {
+              "$ref": "#/components/schemas/domino.datamount.api.DataMountProjectInfoDto"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "pvId": {
             "type": "string"
           },
@@ -3692,6 +4333,29 @@
           "isPublic",
           "isRegistered",
           "dataPlanes"
+        ]
+      },
+      "domino.datamount.api.DataMountProjectInfoDto": {
+        "properties": {
+          "isProjectArchived": {
+            "type": "boolean"
+          },
+          "projectId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "projectName": {
+            "type": "string"
+          },
+          "projectOwnerUsername": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "projectId",
+          "projectName",
+          "projectOwnerUsername",
+          "isProjectArchived"
         ]
       },
       "domino.datamount.web.CreateDataMountRequest": {
@@ -3995,6 +4659,9 @@
           "message": {
             "type": "string"
           },
+          "requiresUpgrade": {
+            "type": "boolean"
+          },
           "state": {
             "enum": [
               "Healthy",
@@ -4011,6 +4678,17 @@
         "required": [
           "state",
           "message",
+          "version",
+          "requiresUpgrade"
+        ]
+      },
+      "domino.dataplane.TargetDataPlaneVersionDto": {
+        "properties": {
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
           "version"
         ]
       },
@@ -4045,7 +4723,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -4513,6 +5191,15 @@
       },
       "domino.datasetrw.api.DatasetRwFiletaskCopyUpdateDto": {
         "properties": {
+          "errorCode": {
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "errorMessage": {
+            "nullable": true,
+            "type": "string"
+          },
           "progress": {
             "format": "int64",
             "type": "integer"
@@ -4636,6 +5323,7 @@
           "UpdateDatasetRwV2",
           "PerformDatasetRwActionsAsAdminV2"
         ],
+        "properties": {},
         "type": "string"
       },
       "domino.datasetrw.api.DatasetRwProjectDetailsDto": {
@@ -4822,6 +5510,7 @@
           "Active",
           "Pending"
         ],
+        "properties": {},
         "type": "string"
       },
       "domino.datasetrw.api.DatasetRwSnapshotAdminSummaryDto": {
@@ -4999,6 +5688,40 @@
           "isReadWrite"
         ]
       },
+      "domino.datasetrw.api.DatasetRwStorageUsageDto": {
+        "properties": {
+          "isAtEmailThreshold": {
+            "type": "boolean"
+          },
+          "isAtWarningThreshold": {
+            "type": "boolean"
+          },
+          "limit": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "quotaId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "targetId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "totalStorageUsed": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "quotaId",
+          "limit",
+          "totalStorageUsed",
+          "isAtWarningThreshold",
+          "isAtEmailThreshold"
+        ],
+        "type": "object"
+      },
       "domino.datasetrw.api.DatasetRwSummaryDto": {
         "properties": {
           "description": {
@@ -5069,7 +5792,7 @@
             "type": "string"
           },
           "lastTouched": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "uploadKey": {
@@ -5470,6 +6193,61 @@
           "status"
         ]
       },
+      "domino.datasource.api.DataSourceAccessedInfo": {
+        "properties": {
+          "dataSourceId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "dataSourceName": {
+            "type": "string"
+          },
+          "dataSourceType": {
+            "enum": [
+              "ADLSConfig",
+              "AzureBlobStorageConfig",
+              "BigQueryConfig",
+              "ClickHouseConfig",
+              "DatabricksConfig",
+              "DB2Config",
+              "DruidConfig",
+              "GCSConfig",
+              "GenericJDBCConfig",
+              "GenericS3Config",
+              "GreenplumConfig",
+              "IgniteConfig",
+              "MariaDBConfig",
+              "MongoDBConfig",
+              "MySQLConfig",
+              "NetezzaConfig",
+              "OracleConfig",
+              "PalantirConfig",
+              "PostgreSQLConfig",
+              "RedshiftConfig",
+              "S3Config",
+              "SAPHanaConfig",
+              "SingleStoreConfig",
+              "SQLServerConfig",
+              "SnowflakeConfig",
+              "SynapseConfig",
+              "TabularS3GlueConfig",
+              "TeradataConfig",
+              "TrinoConfig",
+              "VerticaConfig"
+            ],
+            "type": "string"
+          },
+          "ownerName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "dataSourceId",
+          "dataSourceName",
+          "dataSourceType",
+          "ownerName"
+        ]
+      },
       "domino.datasource.api.DataSourceAdminInfoDto": {
         "properties": {
           "projectIdOwnerUsernameMap": {
@@ -5551,6 +6329,7 @@
               "AWSIAMRole",
               "AWSIAMRoleWithUsername",
               "OAuth",
+              "PersonalToken",
               "UserOnly",
               "BasicOptional",
               "NoAuth",
@@ -5576,21 +6355,35 @@
           "dataSourceType": {
             "enum": [
               "ADLSConfig",
+              "AzureBlobStorageConfig",
               "BigQueryConfig",
+              "ClickHouseConfig",
+              "DatabricksConfig",
+              "DB2Config",
+              "DruidConfig",
               "GCSConfig",
+              "GenericJDBCConfig",
               "GenericS3Config",
+              "GreenplumConfig",
+              "IgniteConfig",
+              "MariaDBConfig",
               "MongoDBConfig",
               "MySQLConfig",
+              "NetezzaConfig",
               "OracleConfig",
+              "PalantirConfig",
               "PostgreSQLConfig",
               "RedshiftConfig",
               "S3Config",
+              "SAPHanaConfig",
+              "SingleStoreConfig",
               "SQLServerConfig",
               "SnowflakeConfig",
+              "SynapseConfig",
               "TabularS3GlueConfig",
               "TeradataConfig",
               "TrinoConfig",
-              "PalantirConfig"
+              "VerticaConfig"
             ],
             "type": "string"
           },
@@ -5671,42 +6464,6 @@
         ],
         "type": "object"
       },
-      "domino.datasource.api.DataSourceMetadataDto": {
-        "properties": {
-          "dataSourceType": {
-            "enum": [
-              "ADLSConfig",
-              "BigQueryConfig",
-              "GCSConfig",
-              "GenericS3Config",
-              "MongoDBConfig",
-              "MySQLConfig",
-              "OracleConfig",
-              "PostgreSQLConfig",
-              "RedshiftConfig",
-              "S3Config",
-              "SQLServerConfig",
-              "SnowflakeConfig",
-              "TabularS3GlueConfig",
-              "TeradataConfig",
-              "TrinoConfig",
-              "PalantirConfig"
-            ],
-            "type": "string"
-          },
-          "description": {
-            "nullable": true,
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "dataSourceType"
-        ]
-      },
       "domino.datasource.api.DataSourceOwnerInfoDto": {
         "properties": {
           "isOwnerAdmin": {
@@ -5777,21 +6534,35 @@
           "dataSourceType": {
             "enum": [
               "ADLSConfig",
+              "AzureBlobStorageConfig",
               "BigQueryConfig",
+              "ClickHouseConfig",
+              "DatabricksConfig",
+              "DB2Config",
+              "DruidConfig",
               "GCSConfig",
+              "GenericJDBCConfig",
               "GenericS3Config",
+              "GreenplumConfig",
+              "IgniteConfig",
+              "MariaDBConfig",
               "MongoDBConfig",
               "MySQLConfig",
+              "NetezzaConfig",
               "OracleConfig",
+              "PalantirConfig",
               "PostgreSQLConfig",
               "RedshiftConfig",
               "S3Config",
+              "SAPHanaConfig",
+              "SingleStoreConfig",
               "SQLServerConfig",
               "SnowflakeConfig",
+              "SynapseConfig",
               "TabularS3GlueConfig",
               "TeradataConfig",
               "TrinoConfig",
-              "PalantirConfig"
+              "VerticaConfig"
             ],
             "type": "string"
           },
@@ -5879,10 +6650,36 @@
           "AWSIAMRole",
           "AWSIAMRoleWithUsername",
           "OAuth",
+          "PersonalToken",
           "BasicOptional",
           "UserOnly",
           "NoAuth",
           "ClientIdSecret"
+        ],
+        "type": "string"
+      },
+      "domino.datasource.model.ConnectorGroup": {
+        "enum": [
+          "Native",
+          "Starburst",
+          "StarburstSelfService"
+        ],
+        "type": "string"
+      },
+      "domino.datasource.model.ConnectorType": {
+        "enum": [
+          "clickhouse",
+          "db2",
+          "druid",
+          "genericJdbc",
+          "greenplum",
+          "ignite",
+          "mariadb",
+          "netezza",
+          "sapHana",
+          "singlestore",
+          "synapse",
+          "vertica"
         ],
         "type": "string"
       },
@@ -5893,6 +6690,12 @@
               "$ref": "#/components/schemas/domino.datasource.model.AuthType"
             },
             "type": "array"
+          },
+          "connectorGroup": {
+            "$ref": "#/components/schemas/domino.datasource.model.ConnectorGroup"
+          },
+          "connectorType": {
+            "$ref": "#/components/schemas/domino.datasource.model.ConnectorType"
           },
           "datasourceType": {
             "$ref": "#/components/schemas/domino.datasource.model.DatasourceType"
@@ -5921,21 +6724,35 @@
       "domino.datasource.model.DatasourceType": {
         "enum": [
           "ADLSConfig",
+          "AzureBlobStorageConfig",
           "BigQueryConfig",
+          "ClickHouseConfig",
+          "DatabricksConfig",
+          "DB2Config",
+          "DruidConfig",
           "GCSConfig",
+          "GenericJDBCConfig",
           "GenericS3Config",
+          "GreenplumConfig",
+          "IgniteConfig",
+          "MariaDBConfig",
           "MongoDBConfig",
           "MySQLConfig",
+          "NetezzaConfig",
           "OracleConfig",
+          "PalantirConfig",
           "PostgreSQLConfig",
           "RedshiftConfig",
           "S3Config",
+          "SAPHanaConfig",
+          "SingleStoreConfig",
           "SQLServerConfig",
           "SnowflakeConfig",
+          "SynapseConfig",
           "TabularS3GlueConfig",
           "TeradataConfig",
           "TrinoConfig",
-          "PalantirConfig"
+          "VerticaConfig"
         ],
         "type": "string"
       },
@@ -5951,6 +6768,9 @@
           "alias": {
             "type": "string"
           },
+          "initialValue": {
+            "type": "string"
+          },
           "isOptional": {
             "type": "boolean"
           },
@@ -5961,6 +6781,9 @@
             "type": "boolean"
           },
           "name": {
+            "type": "string"
+          },
+          "placeholder": {
             "type": "string"
           },
           "regexp": {
@@ -6004,6 +6827,7 @@
               "AWSIAMRole",
               "AWSIAMRoleWithUsername",
               "OAuth",
+              "PersonalToken",
               "UserOnly",
               "BasicOptional",
               "NoAuth",
@@ -6019,6 +6843,10 @@
             "nullable": true,
             "type": "string"
           },
+          "catalogCode": {
+            "nullable": true,
+            "type": "string"
+          },
           "credentialType": {
             "enum": [
               "Individual",
@@ -6029,21 +6857,35 @@
           "dataSourceType": {
             "enum": [
               "ADLSConfig",
+              "AzureBlobStorageConfig",
               "BigQueryConfig",
+              "ClickHouseConfig",
+              "DatabricksConfig",
+              "DB2Config",
+              "DruidConfig",
               "GCSConfig",
+              "GenericJDBCConfig",
               "GenericS3Config",
+              "GreenplumConfig",
+              "IgniteConfig",
+              "MariaDBConfig",
               "MongoDBConfig",
               "MySQLConfig",
+              "NetezzaConfig",
               "OracleConfig",
+              "PalantirConfig",
               "PostgreSQLConfig",
               "RedshiftConfig",
               "S3Config",
+              "SAPHanaConfig",
+              "SingleStoreConfig",
               "SQLServerConfig",
               "SnowflakeConfig",
+              "SynapseConfig",
               "TabularS3GlueConfig",
               "TeradataConfig",
               "TrinoConfig",
-              "PalantirConfig"
+              "VerticaConfig"
             ],
             "type": "string"
           },
@@ -6052,6 +6894,14 @@
             "type": "string"
           },
           "host": {
+            "nullable": true,
+            "type": "string"
+          },
+          "httpPath": {
+            "nullable": true,
+            "type": "string"
+          },
+          "networkingProxy": {
             "nullable": true,
             "type": "string"
           },
@@ -6106,6 +6956,7 @@
               "AWSIAMRole",
               "AWSIAMRoleWithUsername",
               "OAuth",
+              "PersonalToken",
               "UserOnly",
               "BasicOptional",
               "NoAuth",
@@ -6129,21 +6980,35 @@
           "dataSourceType": {
             "enum": [
               "ADLSConfig",
+              "AzureBlobStorageConfig",
               "BigQueryConfig",
+              "ClickHouseConfig",
+              "DatabricksConfig",
+              "DB2Config",
+              "DruidConfig",
               "GCSConfig",
+              "GenericJDBCConfig",
               "GenericS3Config",
+              "GreenplumConfig",
+              "IgniteConfig",
+              "MariaDBConfig",
               "MongoDBConfig",
               "MySQLConfig",
+              "NetezzaConfig",
               "OracleConfig",
+              "PalantirConfig",
               "PostgreSQLConfig",
               "RedshiftConfig",
               "S3Config",
+              "SAPHanaConfig",
+              "SingleStoreConfig",
               "SQLServerConfig",
               "SnowflakeConfig",
+              "SynapseConfig",
               "TabularS3GlueConfig",
               "TeradataConfig",
               "TrinoConfig",
-              "PalantirConfig"
+              "VerticaConfig"
             ],
             "type": "string"
           },
@@ -6196,6 +7061,24 @@
           "userIds"
         ]
       },
+      "domino.datasource.web.DataSourcesAccessedInRunResponse": {
+        "properties": {
+          "accessedDataSources": {
+            "items": {
+              "$ref": "#/components/schemas/domino.datasource.api.DataSourceAccessedInfo"
+            },
+            "type": "array"
+          },
+          "runId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "accessedDataSources"
+        ]
+      },
       "domino.datasource.web.GetAdminUsersRequest": {
         "properties": {
           "userIds": {
@@ -6224,6 +7107,28 @@
           "dataSourceIds"
         ]
       },
+      "domino.datasource.web.RecordDataSourceAccessRequest": {
+        "properties": {
+          "clientSource": {
+            "nullable": true,
+            "type": "string"
+          },
+          "dataPlaneId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "runId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "userName": {
+            "nullable": true,
+            "type": "string"
+          }
+        }
+      },
       "domino.datasource.web.UpdateDataSourceConfigRequest": {
         "properties": {
           "accountID": {
@@ -6242,24 +7147,42 @@
             "nullable": true,
             "type": "string"
           },
+          "catalogCode": {
+            "nullable": true,
+            "type": "string"
+          },
           "dataSourceType": {
             "enum": [
               "ADLSConfig",
+              "AzureBlobStorageConfig",
               "BigQueryConfig",
+              "ClickHouseConfig",
+              "DatabricksConfig",
+              "DB2Config",
+              "DruidConfig",
               "GCSConfig",
+              "GenericJDBCConfig",
               "GenericS3Config",
+              "GreenplumConfig",
+              "IgniteConfig",
+              "MariaDBConfig",
               "MongoDBConfig",
               "MySQLConfig",
+              "NetezzaConfig",
               "OracleConfig",
+              "PalantirConfig",
               "PostgreSQLConfig",
               "RedshiftConfig",
               "S3Config",
+              "SAPHanaConfig",
+              "SingleStoreConfig",
               "SQLServerConfig",
               "SnowflakeConfig",
+              "SynapseConfig",
               "TabularS3GlueConfig",
               "TeradataConfig",
               "TrinoConfig",
-              "PalantirConfig"
+              "VerticaConfig"
             ],
             "type": "string"
           },
@@ -6268,6 +7191,14 @@
             "type": "string"
           },
           "host": {
+            "nullable": true,
+            "type": "string"
+          },
+          "httpPath": {
+            "nullable": true,
+            "type": "string"
+          },
+          "networkingProxy": {
             "nullable": true,
             "type": "string"
           },
@@ -6312,6 +7243,7 @@
               "AWSIAMRole",
               "AWSIAMRoleWithUsername",
               "OAuth",
+              "PersonalToken",
               "UserOnly",
               "BasicOptional",
               "NoAuth",
@@ -6379,6 +7311,20 @@
           "userIds"
         ]
       },
+      "domino.environments.api.CreateNewEnvironment": {
+        "properties": {
+          "newEnvironment": {
+            "$ref": "#/components/schemas/domino.environments.api.NewEnvironment"
+          },
+          "newEnvironmentRevision": {
+            "$ref": "#/components/schemas/domino.environments.api.NewEnvironmentRevision"
+          }
+        },
+        "required": [
+          "newEnvironment",
+          "newEnvironmentRevision"
+        ]
+      },
       "domino.environments.api.EnvProjectPagination": {
         "properties": {
           "pageNo": {
@@ -6395,6 +7341,73 @@
           "pageNo"
         ]
       },
+      "domino.environments.api.Environment": {
+        "properties": {
+          "activeRevisionTags": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "archived": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "internalTags": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "isCurated": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/domino.environments.api.EnvironmentOwner",
+            "nullable": true
+          },
+          "supportedClusters": {
+            "items": {
+              "enum": [
+                "Dask",
+                "Spark",
+                "Ray",
+                "MPI"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "visibility": {
+            "enum": [
+              "Global",
+              "Private",
+              "Organization"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "description",
+          "archived",
+          "name",
+          "visibility",
+          "supportedClusters",
+          "isCurated"
+        ]
+      },
       "domino.environments.api.EnvironmentDetails": {
         "properties": {
           "activeRevisionTags": {
@@ -6407,8 +7420,15 @@
           "archived": {
             "type": "boolean"
           },
+          "base": {
+            "$ref": "#/components/schemas/domino.environments.api.EnvironmentRevision",
+            "nullable": true
+          },
           "baseDependenciesInitImage": {
             "nullable": true,
+            "type": "string"
+          },
+          "description": {
             "type": "string"
           },
           "id": {
@@ -6426,8 +7446,17 @@
             "nullable": true,
             "type": "boolean"
           },
+          "lastUpdated": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
           "latestRevision": {
             "$ref": "#/components/schemas/domino.environments.api.RevisionOverview",
+            "nullable": true
+          },
+          "latestRevisionDetails": {
+            "$ref": "#/components/schemas/domino.environments.api.EnvironmentRevision",
             "nullable": true
           },
           "name": {
@@ -6436,6 +7465,11 @@
           "owner": {
             "$ref": "#/components/schemas/domino.environments.api.EnvironmentOwner",
             "nullable": true
+          },
+          "projectsCount": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
           },
           "restrictedRevision": {
             "$ref": "#/components/schemas/domino.environments.api.RevisionOverview",
@@ -6468,6 +7502,7 @@
         },
         "required": [
           "id",
+          "description",
           "archived",
           "name",
           "visibility",
@@ -6497,14 +7532,48 @@
           "environmentOwnerType"
         ]
       },
-      "domino.environments.api.EnvironmentPermissionsResult": {
+      "domino.environments.api.EnvironmentPermissions": {
         "properties": {
-          "canClassifyEnvironments": {
+          "canEdit": {
             "type": "boolean"
           }
         },
         "required": [
-          "canClassifyEnvironments"
+          "canEdit"
+        ]
+      },
+      "domino.environments.api.EnvironmentPermissionsResult": {
+        "properties": {
+          "canClassifyEnvironments": {
+            "type": "boolean"
+          },
+          "canCreateEnvironments": {
+            "type": "boolean"
+          },
+          "canCreateGlobalEnvironment": {
+            "type": "boolean"
+          },
+          "canEditPrivilegedFields": {
+            "type": "boolean"
+          },
+          "canSetEnvironmentsAsDefault": {
+            "type": "boolean"
+          },
+          "canTransferOwnership": {
+            "type": "boolean"
+          },
+          "environment": {
+            "$ref": "#/components/schemas/domino.environments.api.EnvironmentPermissions",
+            "nullable": true
+          }
+        },
+        "required": [
+          "canClassifyEnvironments",
+          "canCreateEnvironments",
+          "canSetEnvironmentsAsDefault",
+          "canTransferOwnership",
+          "canCreateGlobalEnvironment",
+          "canEditPrivilegedFields"
         ]
       },
       "domino.environments.api.EnvironmentProjectUsageSummariesSet": {
@@ -6557,6 +7626,140 @@
           "ownerName",
           "visibility",
           "latestRuns"
+        ]
+      },
+      "domino.environments.api.EnvironmentRevision": {
+        "properties": {
+          "buildEnvironmentVariables": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "clusterTypes": {
+            "items": {
+              "enum": [
+                "Dask",
+                "Spark",
+                "Ray",
+                "MPI"
+              ],
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "dockerArguments": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "dockerImage": {
+            "nullable": true,
+            "type": "string"
+          },
+          "dockerfileInstructions": {
+            "nullable": true,
+            "type": "string"
+          },
+          "environmentId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "id": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "imageType": {
+            "enum": [
+              "DefaultImage",
+              "Environment",
+              "CustomImage"
+            ],
+            "type": "string"
+          },
+          "isBuilt": {
+            "type": "boolean"
+          },
+          "isRestricted": {
+            "type": "boolean"
+          },
+          "number": {
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "postRunScript": {
+            "nullable": true,
+            "type": "string"
+          },
+          "postSetupScript": {
+            "nullable": true,
+            "type": "string"
+          },
+          "preRunScript": {
+            "nullable": true,
+            "type": "string"
+          },
+          "preSetupScript": {
+            "nullable": true,
+            "type": "string"
+          },
+          "shouldUseVPN": {
+            "type": "boolean"
+          },
+          "summary": {
+            "nullable": true,
+            "type": "string"
+          },
+          "workspacesProperties": {
+            "$ref": "#/components/schemas/domino.common.util.yaml.DefaultYamlString",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "environmentId",
+          "imageType",
+          "isRestricted",
+          "isBuilt",
+          "dockerArguments",
+          "shouldUseVPN",
+          "buildEnvironmentVariables"
+        ]
+      },
+      "domino.environments.api.EnvironmentRevisionDetails": {
+        "properties": {
+          "canRevertTo": {
+            "type": "boolean"
+          },
+          "environment": {
+            "$ref": "#/components/schemas/domino.environments.api.Environment"
+          },
+          "environmentRevision": {
+            "$ref": "#/components/schemas/domino.environments.api.EnvironmentRevision"
+          },
+          "hasRunningBuild": {
+            "type": "boolean"
+          },
+          "isLatestRevision": {
+            "type": "boolean"
+          },
+          "visibleEnvironments": {
+            "$ref": "#/components/schemas/domino.environments.api.VisibleEnvironments"
+          }
+        },
+        "required": [
+          "environment",
+          "environmentRevision",
+          "isLatestRevision",
+          "visibleEnvironments",
+          "canRevertTo",
+          "hasRunningBuild"
         ]
       },
       "domino.environments.api.EnvironmentRevisionSummary": {
@@ -6647,6 +7850,170 @@
           "title",
           "start"
         ]
+      },
+      "domino.environments.api.NewEnvironment": {
+        "properties": {
+          "addBaseDependencies": {
+            "type": "boolean"
+          },
+          "clusterTypes": {
+            "items": {
+              "enum": [
+                "Dask",
+                "Spark",
+                "Ray",
+                "MPI"
+              ],
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "isCurated": {
+            "type": "boolean"
+          },
+          "isRestricted": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ownerId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "projectsCount": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "skipFirstBuild": {
+            "type": "boolean"
+          },
+          "visibility": {
+            "enum": [
+              "Global",
+              "Private",
+              "Organization"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "visibility",
+          "addBaseDependencies",
+          "isCurated",
+          "skipFirstBuild"
+        ]
+      },
+      "domino.environments.api.NewEnvironmentRevision": {
+        "properties": {
+          "baseRevision": {
+            "$ref": "#/components/schemas/domino.environments.api.NewEnvironmentRevisionBase"
+          },
+          "dockerArguments": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "dockerfileInstructions": {
+            "nullable": true,
+            "type": "string"
+          },
+          "environmentVariables": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "isRestricted": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "postRunScript": {
+            "nullable": true,
+            "type": "string"
+          },
+          "postSetupScript": {
+            "nullable": true,
+            "type": "string"
+          },
+          "preRunScript": {
+            "nullable": true,
+            "type": "string"
+          },
+          "preSetupScript": {
+            "nullable": true,
+            "type": "string"
+          },
+          "shouldUseVpn": {
+            "type": "boolean"
+          },
+          "skipCache": {
+            "type": "boolean"
+          },
+          "summary": {
+            "nullable": true,
+            "type": "string"
+          },
+          "supportedClusters": {
+            "items": {
+              "enum": [
+                "Dask",
+                "Spark",
+                "Ray",
+                "MPI"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "workspaceTools": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "baseRevision",
+          "supportedClusters",
+          "environmentVariables",
+          "dockerArguments",
+          "skipCache",
+          "shouldUseVpn"
+        ]
+      },
+      "domino.environments.api.NewEnvironmentRevisionBase": {
+        "properties": {
+          "baseRevisionId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "image": {
+            "nullable": true,
+            "type": "string"
+          }
+        }
       },
       "domino.environments.api.PaginatedRevisionData": {
         "properties": {
@@ -6764,7 +8131,7 @@
       "domino.environments.api.RevisionSummary": {
         "properties": {
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "id": {
@@ -6801,6 +8168,47 @@
         },
         "required": [
           "isRestricted"
+        ]
+      },
+      "domino.environments.api.VisibilityUpdateRequest": {
+        "properties": {
+          "ownerId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "visibility": {
+            "enum": [
+              "Global",
+              "Private",
+              "Organization"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "visibility"
+        ]
+      },
+      "domino.environments.api.VisibleEnvironments": {
+        "properties": {
+          "activeEnvironmentRevisions": {
+            "items": {
+              "$ref": "#/components/schemas/domino.environments.api.EnvironmentRevisionSummary"
+            },
+            "type": "array"
+          },
+          "defaultEnv": {
+            "$ref": "#/components/schemas/domino.environments.api.Environment"
+          },
+          "defaultEnvRev": {
+            "$ref": "#/components/schemas/domino.environments.api.EnvironmentRevision",
+            "nullable": true
+          }
+        },
+        "required": [
+          "activeEnvironmentRevisions",
+          "defaultEnv"
         ]
       },
       "domino.executor.api.BranchEntryDto": {
@@ -7196,8 +8604,7 @@
       "domino.featurestore.api.FeatureViewDto": {
         "properties": {
           "addedBy": {
-            "additionalProperties": true,
-            "type": "object"
+            "type": "collection.immutable.map[domino.common.dominoid,string]"
           },
           "author": {
             "nullable": true,
@@ -7484,7 +8891,7 @@
             "$ref": "#/components/schemas/domino.files.interface.CommentedBy"
           },
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -8704,10 +10111,18 @@
           "isDefault": {
             "type": "boolean"
           },
+          "isDefaultForModelApi": {
+            "nullable": true,
+            "type": "boolean"
+          },
           "isFree": {
             "type": "boolean"
           },
           "isGlobal": {
+            "type": "boolean"
+          },
+          "isModelApiTier": {
+            "nullable": true,
             "type": "boolean"
           },
           "isVisible": {
@@ -8987,10 +10402,18 @@
           "isDefault": {
             "type": "boolean"
           },
+          "isDefaultForModelApi": {
+            "nullable": true,
+            "type": "boolean"
+          },
           "isFree": {
             "type": "boolean"
           },
           "isGlobal": {
+            "type": "boolean"
+          },
+          "isModelApiTier": {
+            "nullable": true,
             "type": "boolean"
           },
           "isVisible": {
@@ -9170,7 +10593,7 @@
             "$ref": "#/components/schemas/domino.jobs.interface.Commenter"
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -9474,6 +10897,10 @@
       },
       "domino.jobs.interface.Environment": {
         "properties": {
+          "environmentId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
           "environmentName": {
             "type": "string"
           },
@@ -9511,6 +10938,7 @@
           }
         },
         "required": [
+          "environmentId",
           "environmentName",
           "environmentRevisionSpec"
         ]
@@ -9819,7 +11247,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -9975,22 +11403,12 @@
           },
           "isScheduled": {
             "type": "boolean"
-          },
-          "volumeRecoverabilityStatus": {
-            "enum": [
-              "Unauthorized",
-              "VolumeUnavailable",
-              "Recoverable",
-              "NoActionNecessary"
-            ],
-            "type": "string"
           }
         },
         "required": [
           "isCompleted",
           "isArchived",
           "isScheduled",
-          "volumeRecoverabilityStatus",
           "executionStatus"
         ]
       },
@@ -10042,7 +11460,7 @@
             "type": "integer"
           },
           "jobStartTime": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "jobStatus": {
@@ -10100,7 +11518,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -10240,7 +11658,7 @@
             "type": "string"
           },
           "lastModified": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "size": {
@@ -10259,17 +11677,17 @@
       "domino.jobs.interface.StageTime": {
         "properties": {
           "completedTime": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
           "runStartTime": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
           "submissionTime": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -10294,7 +11712,7 @@
       "domino.jobs.interface.TagApplication": {
         "properties": {
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -10450,7 +11868,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -10504,7 +11922,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -10861,6 +12279,12 @@
       },
       "domino.mlflow.api.MlflowData": {
         "properties": {
+          "accessedDataSources": {
+            "items": {
+              "$ref": "#/components/schemas/domino.datasource.api.DataSourceAccessedInfo"
+            },
+            "type": "array"
+          },
           "dataSources": {
             "type": "string"
           },
@@ -10919,7 +12343,35 @@
           "mlflowSourceType",
           "runNumber",
           "datasetInfo",
-          "dataSources"
+          "dataSources",
+          "accessedDataSources"
+        ]
+      },
+      "domino.mlflow.api.MlflowProjectInfo": {
+        "properties": {
+          "collaborators": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.CollaboratorDTO"
+            },
+            "type": "array"
+          },
+          "id": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ownerId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "ownerId",
+          "collaborators"
         ]
       },
       "domino.mlflow.api.PreviewFileConfigDTO": {
@@ -10931,6 +12383,71 @@
         },
         "required": [
           "maxPreviewFileSizeMB"
+        ]
+      },
+      "domino.modelmanager.api.DeploymentLabels": {
+        "properties": {
+          "containerNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "podNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "podNames",
+          "containerNames"
+        ]
+      },
+      "domino.modelmanager.api.LogLine": {
+        "properties": {
+          "log": {
+            "type": "string"
+          },
+          "streamType": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/domino.modelmanager.api.LogTag"
+            },
+            "type": "array"
+          },
+          "timeNano": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "timestamp": {
+            "format": "epoch",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "timestamp",
+          "timeNano",
+          "log",
+          "streamType",
+          "tags"
+        ]
+      },
+      "domino.modelmanager.api.LogTag": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "value"
         ]
       },
       "domino.modelmanager.api.Model": {
@@ -10954,6 +12471,7 @@
             "enum": [
               "Starting",
               "Ready to run",
+              "Unreachable",
               "Running",
               "Preparing to build",
               "Failed",
@@ -10975,7 +12493,7 @@
             "type": "boolean"
           },
           "lastModified": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "name": {
@@ -11025,7 +12543,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -11140,10 +12658,43 @@
           "logs"
         ]
       },
+      "domino.modelmanager.api.ModelBuildLogsV2": {
+        "properties": {
+          "logs": {
+            "items": {
+              "$ref": "#/components/schemas/domino.modelmanager.api.LogLine"
+            },
+            "type": "array"
+          },
+          "modelId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "modelVersionId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "preparing",
+              "building",
+              "complete",
+              "failed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "modelId",
+          "modelVersionId",
+          "status",
+          "logs"
+        ]
+      },
       "domino.modelmanager.api.ModelExport": {
         "properties": {
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "id": {
@@ -11197,6 +12748,45 @@
           "created"
         ]
       },
+      "domino.modelmanager.api.ModelExportLogs": {
+        "properties": {
+          "logs": {
+            "items": {
+              "$ref": "#/components/schemas/domino.modelmanager.api.LogLine"
+            },
+            "type": "array"
+          },
+          "modelId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "modelVersionId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "sinceTimeNano": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "status": {
+            "enum": [
+              "exporting",
+              "preparing",
+              "complete",
+              "not_triggered",
+              "failed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "modelId",
+          "modelVersionId",
+          "status",
+          "logs"
+        ]
+      },
       "domino.modelmanager.api.ModelExportTargetDetails": {
         "properties": {}
       },
@@ -11208,7 +12798,7 @@
             "type": "string"
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "exportId": {
@@ -11376,6 +12966,51 @@
           "modelId"
         ]
       },
+      "domino.modelmanager.api.ModelInstanceLogs": {
+        "properties": {
+          "containerName": {
+            "nullable": true,
+            "type": "string"
+          },
+          "logs": {
+            "items": {
+              "$ref": "#/components/schemas/domino.modelmanager.api.LogLine"
+            },
+            "type": "array"
+          },
+          "maxResults": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "modelId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "modelVersionId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "podName": {
+            "nullable": true,
+            "type": "string"
+          },
+          "sinceTimeNano": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "tail": {
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "modelId",
+          "modelVersionId",
+          "maxResults",
+          "logs"
+        ]
+      },
       "domino.modelmanager.api.ModelOwner": {
         "properties": {
           "fullName": {
@@ -11401,7 +13036,7 @@
             "type": "string"
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -11564,8 +13199,7 @@
             "type": "integer"
           },
           "modelAccess": {
-            "additionalProperties": true,
-            "type": "object"
+            "type": "collection.immutable.map[domino.common.dominoid,domino.server.modelmanager.application.modeldetailsaccess]"
           },
           "models": {
             "items": {
@@ -11697,6 +13331,21 @@
           "startIndex",
           "totalItems",
           "items"
+        ]
+      },
+      "domino.modelmanager.api.responses.ModelPermissionForMonitoringApiResponse": {
+        "properties": {
+          "canListModelApi": {
+            "type": "boolean"
+          },
+          "modelId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "modelId",
+          "canListModelApi"
         ]
       },
       "domino.modelmanager.api.responses.ModelPermissionsForUIApiResponse": {
@@ -12472,7 +14121,7 @@
           "Critical",
           "Default"
         ],
-        "type": "string"
+        "type": "String"
       },
       "domino.notifications.Timeframe": {
         "properties": {
@@ -13970,6 +15619,10 @@
           "tags": {
             "$ref": "#/components/schemas/domino.projects.api.NewTagsDTO"
           },
+          "templateDetails": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateDetails",
+            "nullable": true
+          },
           "visibility": {
             "enum": [
               "Public",
@@ -14055,6 +15708,10 @@
               "$ref": "#/components/schemas/domino.projects.api.ProjectTagDTO"
             },
             "type": "array"
+          },
+          "templateDetails": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateDetails",
+            "nullable": true
           },
           "visibility": {
             "type": "string"
@@ -14203,7 +15860,7 @@
             "type": "array"
           },
           "updatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -14248,7 +15905,7 @@
             "type": "string"
           },
           "updatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -14265,7 +15922,7 @@
       "domino.projectManagement.api.FullSyncStatus": {
         "properties": {
           "lastSyncInitiatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "syncStatus": {
@@ -14319,7 +15976,7 @@
             "nullable": true
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "dominoEntity": {
@@ -14330,7 +15987,7 @@
             "$ref": "#/components/schemas/domino.projectManagement.api.PmId"
           },
           "updatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -14479,7 +16136,7 @@
             "type": "string"
           },
           "updatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -14626,6 +16283,17 @@
           "isDeleted"
         ]
       },
+      "domino.projectManagement.web.ArchiveProjectGoalStage": {
+        "properties": {
+          "stageId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "stageId"
+        ]
+      },
       "domino.projectManagement.web.CommentRequest": {
         "properties": {
           "comment": {
@@ -14634,6 +16302,16 @@
         },
         "required": [
           "comment"
+        ]
+      },
+      "domino.projectManagement.web.CreateProjectGoalStage": {
+        "properties": {
+          "stageName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "stageName"
         ]
       },
       "domino.projectManagement.web.ErrorResponse": {
@@ -14653,6 +16331,26 @@
           "code"
         ],
         "type": "object"
+      },
+      "domino.projectManagement.web.FilterProjectGoals": {
+        "properties": {
+          "assigneeIds": {
+            "items": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "stageIds": {
+            "items": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        }
       },
       "domino.projectManagement.web.LinkFileToGoalRequest": {
         "properties": {
@@ -14766,6 +16464,21 @@
           "goalId"
         ]
       },
+      "domino.projectManagement.web.UpdateProjectGoalStage": {
+        "properties": {
+          "stageId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "stageName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "stageId",
+          "stageName"
+        ]
+      },
       "domino.projects.api.AssetPortfolioElement": {
         "properties": {
           "assetId": {
@@ -14784,7 +16497,7 @@
             "type": "string"
           },
           "lastUpdatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
@@ -14837,7 +16550,7 @@
       "domino.projects.api.AssetPortfolioPaginationFilter": {
         "properties": {
           "pagination": {
-            "type": "string"
+            "type": "domino.apiserverutils.pagination.paginationfilter"
           },
           "searchQuery": {
             "nullable": true,
@@ -14903,7 +16616,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "usageCount": {
@@ -14939,7 +16652,7 @@
             "$ref": "#/components/schemas/domino.projects.api.ProjectStakeholder"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -15027,11 +16740,11 @@
             "$ref": "#/components/schemas/domino.projects.api.Commenter"
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "updatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -15203,7 +16916,7 @@
             "$ref": "#/components/schemas/domino.projects.api.EntityLinkMetadata"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -15343,6 +17056,34 @@
         },
         "required": [
           "uri"
+        ]
+      },
+      "domino.projects.api.NamedLink": {
+        "properties": {
+          "link": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "link"
+        ]
+      },
+      "domino.projects.api.NamedOptionalLink": {
+        "properties": {
+          "link": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
         ]
       },
       "domino.projects.api.NewTagsDTO": {
@@ -15648,8 +17389,13 @@
       },
       "domino.projects.api.ProjectGoal": {
         "properties": {
+          "assigneeId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -15674,12 +17420,17 @@
             "type": "boolean"
           },
           "lastDescriptionUpdatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
           "lastTitleUpdatedAt": {
-            "format": "int64",
+            "format": "epoch",
+            "nullable": true,
+            "type": "integer"
+          },
+          "lastUpdatedAt": {
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
@@ -15719,7 +17470,7 @@
             "type": "boolean"
           },
           "lastStageUpdatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "stage": {
@@ -15731,6 +17482,209 @@
           "isCompleted",
           "stage",
           "lastStageUpdatedAt"
+        ]
+      },
+      "domino.projects.api.ProjectHubModel": {
+        "properties": {
+          "link": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectHubTemplateSize",
+            "nullable": true
+          },
+          "source": {
+            "$ref": "#/components/schemas/domino.projects.api.NamedLink",
+            "nullable": true
+          }
+        },
+        "required": [
+          "name",
+          "link"
+        ]
+      },
+      "domino.projects.api.ProjectHubTemplateResult": {
+        "properties": {
+          "base64Logo": {
+            "nullable": true,
+            "type": "string"
+          },
+          "categories": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "created": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/components/schemas/domino.projects.api.NamedOptionalLink",
+            "nullable": true
+          },
+          "dataFormat": {
+            "nullable": true,
+            "type": "string"
+          },
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "environment": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateEnvironment",
+            "nullable": true
+          },
+          "environmentReqs": {
+            "$ref": "#/components/schemas/domino.projects.api.ValueOptionalLink",
+            "nullable": true
+          },
+          "goals": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateGoals"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "hardwareTier": {
+            "$ref": "#/components/schemas/domino.projects.api.ValueOptionalLink",
+            "nullable": true
+          },
+          "importedRepositories": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateImportedRepository"
+            },
+            "type": "array"
+          },
+          "license": {
+            "$ref": "#/components/schemas/domino.projects.api.NamedLink",
+            "nullable": true
+          },
+          "mainRepository": {
+            "$ref": "#/components/schemas/domino.projects.api.repositories.responses.ProjectTemplateRepositoryDTO"
+          },
+          "models": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.ProjectHubModel"
+            },
+            "type": "array"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/domino.projects.api.NamedLink"
+          },
+          "prerequisites": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.ProjectTemplatePrerequisites"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "recommended": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "revisionId": {
+            "type": "string"
+          },
+          "templateId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "updated": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "templateId",
+          "title",
+          "categories",
+          "mainRepository",
+          "created",
+          "updated",
+          "owner",
+          "models",
+          "revisionId",
+          "importedRepositories"
+        ]
+      },
+      "domino.projects.api.ProjectHubTemplateSize": {
+        "properties": {
+          "units": {
+            "type": "string"
+          },
+          "value": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "value",
+          "units"
+        ]
+      },
+      "domino.projects.api.ProjectHubTemplatesResult": {
+        "properties": {
+          "base64Logo": {
+            "nullable": true,
+            "type": "string"
+          },
+          "categories": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "created": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "dataFormat": {
+            "nullable": true,
+            "type": "string"
+          },
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "license": {
+            "$ref": "#/components/schemas/domino.projects.api.NamedLink",
+            "nullable": true
+          },
+          "owner": {
+            "$ref": "#/components/schemas/domino.projects.api.NamedLink"
+          },
+          "recommended": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "revisionId": {
+            "type": "string"
+          },
+          "templateId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "updated": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "templateId",
+          "title",
+          "categories",
+          "created",
+          "updated",
+          "owner",
+          "revisionId"
         ]
       },
       "domino.projects.api.ProjectInfo": {
@@ -15779,10 +17733,18 @@
         "properties": {
           "canClassifyProjects": {
             "type": "boolean"
+          },
+          "canCreateProjects": {
+            "type": "boolean"
+          },
+          "currentProjectPermissions": {
+            "$ref": "#/components/schemas/domino.projects.api.SingleProjectPermissionResult",
+            "nullable": true
           }
         },
         "required": [
-          "canClassifyProjects"
+          "canClassifyProjects",
+          "canCreateProjects"
         ]
       },
       "domino.projects.api.ProjectPortfolioElement": {
@@ -15808,7 +17770,7 @@
             "type": "number"
           },
           "createdOn": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "duration": {
@@ -15816,7 +17778,7 @@
             "type": "integer"
           },
           "lastActivity": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
@@ -15877,7 +17839,7 @@
             "type": "boolean"
           },
           "pagination": {
-            "type": "string"
+            "type": "domino.apiserverutils.pagination.paginationfilter"
           },
           "searchQuery": {
             "nullable": true,
@@ -15970,7 +17932,7 @@
       "domino.projects.api.ProjectStage": {
         "properties": {
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -16144,6 +18106,10 @@
             },
             "type": "array"
           },
+          "templateDetails": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateDetails",
+            "nullable": true
+          },
           "visibility": {
             "type": "string"
           }
@@ -16180,6 +18146,81 @@
           "id",
           "name",
           "isApproved"
+        ]
+      },
+      "domino.projects.api.ProjectTemplateDetails": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "templateId": {
+            "type": "string"
+          },
+          "templateRevisionId": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "templateId"
+        ]
+      },
+      "domino.projects.api.ProjectTemplateEnvironment": {
+        "properties": {
+          "id": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "link": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "link"
+        ]
+      },
+      "domino.projects.api.ProjectTemplateGoals": {
+        "properties": {
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
+      "domino.projects.api.ProjectTemplateImportedRepository": {
+        "properties": {
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "uri"
+        ]
+      },
+      "domino.projects.api.ProjectTemplatePrerequisites": {
+        "properties": {
+          "link": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value",
+          "link"
         ]
       },
       "domino.projects.api.ProxyConfig": {
@@ -16314,6 +18355,20 @@
           "latestRevisionUrl"
         ]
       },
+      "domino.projects.api.SingleProjectPermissionResult": {
+        "properties": {
+          "canCopy": {
+            "type": "boolean"
+          },
+          "canFork": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "canFork",
+          "canCopy"
+        ]
+      },
       "domino.projects.api.StageStat": {
         "properties": {
           "id": {
@@ -16369,6 +18424,20 @@
         },
         "required": [
           "environments"
+        ]
+      },
+      "domino.projects.api.ValueOptionalLink": {
+        "properties": {
+          "link": {
+            "nullable": true,
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value"
         ]
       },
       "domino.projects.api.WritableProjectMounts": {
@@ -16639,7 +18708,7 @@
           "summary"
         ]
       },
-      "domino.projects.api.repositories.responses.GitApiResponseWrapper": {
+      "domino.projects.api.repositories.responses.GitApiResponseWrapper[domino.gitproviders.api.GetOwnersApiResponse]": {
         "properties": {
           "data": {
             "$ref": "#/components/schemas/domino.gitproviders.api.GetOwnersApiResponse"
@@ -16649,10 +18718,42 @@
           "data"
         ]
       },
+      "domino.projects.api.repositories.responses.ProjectTemplateReferenceDTO": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "domino.projects.api.repositories.responses.ProjectTemplateRepositoryDTO": {
+        "properties": {
+          "ref": {
+            "$ref": "#/components/schemas/domino.projects.api.repositories.responses.ProjectTemplateReferenceDTO"
+          },
+          "serviceProvider": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "uri",
+          "ref",
+          "serviceProvider"
+        ]
+      },
       "domino.projects.api.repositories.responses.browse.CommitAuthorDTO": {
         "properties": {
           "date": {
-            "type": "string"
+            "type": "date"
           },
           "name": {
             "type": "string"
@@ -16756,7 +18857,7 @@
       "domino.projects.web.AddBlockedAtComment": {
         "properties": {
           "blockedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "comment": {
@@ -16807,8 +18908,18 @@
       },
       "domino.projects.web.CreateProjectGoal": {
         "properties": {
+          "assigneeId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
           "description": {
             "nullable": true,
+            "type": "string"
+          },
+          "stageId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
             "type": "string"
           },
           "title": {
@@ -17552,6 +19663,28 @@
           "humanReadableCronString"
         ]
       },
+      "domino.scheduledjob.api.DataConfigDto": {
+        "properties": {
+          "datasetConfig": {
+            "nullable": true,
+            "type": "string"
+          },
+          "externalVolumeMounts": {
+            "items": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "snapshotDatasetsOnCompletion": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "snapshotDatasetsOnCompletion"
+        ]
+      },
       "domino.scheduledjob.api.EditCronScheduleDTO": {
         "properties": {
           "cronString": {
@@ -17646,6 +19779,14 @@
               }
             ]
           },
+          "externalVolumeMounts": {
+            "items": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "hardwareTierIdentifier": {
             "type": "string"
           },
@@ -17690,9 +19831,8 @@
             "type": "string"
           },
           "volumeSpecificationOverride": {
-            "additionalProperties": true,
             "nullable": true,
-            "type": "object"
+            "type": "domino.run.api.volume.runondemandvolumespecification"
           }
         },
         "required": [
@@ -17724,9 +19864,8 @@
             "format": "date-time",
             "type": "string"
           },
-          "datasetConfig": {
-            "nullable": true,
-            "type": "string"
+          "dataConfig": {
+            "$ref": "#/components/schemas/domino.scheduledjob.api.DataConfigDto"
           },
           "environmentRevisionSpec": {
             "oneOf": [
@@ -17796,9 +19935,6 @@
           "scheduledByUserName": {
             "type": "string"
           },
-          "snapshotDatasetsOnCompletion": {
-            "type": "boolean"
-          },
           "timezoneId": {
             "type": "string"
           },
@@ -17806,9 +19942,8 @@
             "type": "string"
           },
           "volumeSpecificationOverride": {
-            "additionalProperties": true,
             "nullable": true,
-            "type": "object"
+            "type": "domino.run.api.volume.runondemandvolumespecification"
           }
         },
         "required": [
@@ -17827,7 +19962,7 @@
           "scheduledByUserId",
           "scheduledByUserName",
           "notifyOnCompleteEmailAddresses",
-          "snapshotDatasetsOnCompletion"
+          "dataConfig"
         ]
       },
       "domino.scheduledjob.api.ScheduledJobForRequestingUserDto": {
@@ -17882,6 +20017,14 @@
               }
             ]
           },
+          "externalVolumeMounts": {
+            "items": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "hardwareTierIdentifier": {
             "type": "string"
           },
@@ -17926,9 +20069,8 @@
             "type": "string"
           },
           "volumeSpecificationOverride": {
-            "additionalProperties": true,
             "nullable": true,
-            "type": "object"
+            "type": "domino.run.api.volume.runondemandvolumespecification"
           }
         },
         "required": [
@@ -18180,7 +20322,7 @@
       "domino.server.projectreleases.ProjectReleaseDto": {
         "properties": {
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -18376,6 +20518,10 @@
               "$ref": "#/components/schemas/domino.server.projects.api.ProjectGatewayTag"
             },
             "type": "array"
+          },
+          "templateDetails": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateDetails",
+            "nullable": true
           },
           "totalRunTime": {
             "description": "sum of run times of all executions in the project, in ISO8601 duration format including only seconds and milliseconds",
@@ -18732,6 +20878,11 @@
       },
       "domino.workspace.api.DataMountSpecificationDto": {
         "properties": {
+          "id": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
           "mount": {
             "$ref": "#/components/schemas/domino.workspace.api.VolumeMountDto"
           },
@@ -18925,7 +21076,7 @@
           },
           "diskUsage": {
             "nullable": true,
-            "type": "string"
+            "type": "domino.run.api.rundiskusage"
           },
           "environmentName": {
             "type": "string"
@@ -20239,7 +22390,7 @@
             "$ref": "#/components/schemas/domino.workspaces.api.Commenter"
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -20606,7 +22757,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -20722,7 +22873,7 @@
             "type": "string"
           },
           "lastModified": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "size": {
@@ -20741,17 +22892,17 @@
       "domino.workspaces.api.StageTime": {
         "properties": {
           "completedTime": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
           "startTime": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
           "submissionTime": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -20873,15 +23024,6 @@
           "usage": {
             "$ref": "#/components/schemas/domino.workspaces.api.WorkspaceResourceUsage",
             "nullable": true
-          },
-          "volumeRecoverabilityStatus": {
-            "enum": [
-              "Unauthorized",
-              "VolumeUnavailable",
-              "Recoverable",
-              "NoActionNecessary"
-            ],
-            "type": "string"
           }
         },
         "required": [
@@ -20897,7 +23039,6 @@
           "tags",
           "commentsCount",
           "status",
-          "volumeRecoverabilityStatus",
           "inputCommitId",
           "dominoStats",
           "dependentRepositories",
@@ -21019,7 +23160,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -21162,7 +23303,7 @@
       "domino.workspaces.api.WorkspaceTag": {
         "properties": {
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -21450,7 +23591,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "workspaceId": {
@@ -21488,7 +23629,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "workspaceId": {
@@ -21750,7 +23891,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -21761,7 +23902,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -21775,11 +23916,13 @@
                   "project",
                   "job",
                   "model_api",
-                  "workspace",
                   "comment",
                   "app",
+                  "goals",
                   "schedule_job",
-                  "files"
+                  "files",
+                  "workspace",
+                  "registered_model"
                 ],
                 "type": "string"
               },
@@ -21820,7 +23963,7 @@
     },
     "/activity/metadata": {
       "get": {
-        "operationId": "getActivityMetadata",
+        "operationId": "notFound",
         "responses": {
           "200": {
             "content": {
@@ -21848,6 +23991,255 @@
         "summary": "Metadata entries.",
         "tags": [
           "Activity"
+        ]
+      }
+    },
+    "/activity/registered_model": {
+      "get": {
+        "operationId": "getRegisteredModelActivityStream",
+        "parameters": [
+          {
+            "description": "Name of the registered model",
+            "in": "query",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number of the registered model",
+            "in": "query",
+            "name": "modelVersion",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "page size to get the activity",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "nullable": true,
+              "type": "number"
+            }
+          },
+          {
+            "description": "latest time stamp of the activity",
+            "in": "query",
+            "name": "latestTimeStamp",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "nullable": true,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.activity.api.ActivityStream"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Gets the activity stream for a registered model",
+        "tags": [
+          "Activity"
+        ]
+      }
+    },
+    "/admin/centralConfigSettings": {
+      "get": {
+        "operationId": "getCentralConfigSettings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.admin.interface.ConfigSettingEntityDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Gets all central config settings",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "post": {
+        "operationId": "createCentralConfigSetting",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.admin.interface.ConfigSettingDto"
+              }
+            }
+          },
+          "description": "config setting to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.admin.interface.ConfigSettingEntityDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Create a new central config setting",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/admin/centralConfigSettings/{id}": {
+      "delete": {
+        "operationId": "deleteCentralConfigSetting",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Delete a central config setting",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "put": {
+        "operationId": "updateCentralConfigSetting",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.admin.interface.ConfigSettingDto"
+              }
+            }
+          },
+          "description": "config setting to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.admin.interface.ConfigSettingEntityDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Update a central config setting",
+        "tags": [
+          "Admin"
         ]
       }
     },
@@ -22219,7 +24611,6 @@
     "/admin/notifications/admin": {
       "post": {
         "operationId": "createNotificationSuperUser",
-        "responses": {},
         "tags": [
           "adminnotifications"
         ]
@@ -22438,7 +24829,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -22483,7 +24875,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -22528,7 +24921,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -22703,10 +25097,9 @@
     "/controlCenter/utilization/kubecostDeployed": {
       "get": {
         "operationId": "getKubecostLiveness",
-        "responses": {},
         "summary": "this endpoint will be temporarily used to discover if Kubecost is installed and will be removed if we retire the current cost& compute page",
         "tags": [
-          "Control Center"
+          "controlcenter"
         ]
       }
     },
@@ -23591,6 +25984,18 @@
     "/datamount/all": {
       "get": {
         "operationId": "getAllRegisteredDataMounts",
+        "parameters": [
+          {
+            "description": "boolean to update statuses of all outdated datmaounts",
+            "in": "query",
+            "name": "updateStatuses",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -24527,7 +26932,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/domino.dataplane.DataPlane"
+                  "type": "#/components/schemas/domino.dataplane.DataPlane"
                 }
               }
             },
@@ -24619,7 +27024,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/domino.dataplane.DataPlane"
+                  "type": "#/components/schemas/domino.dataplane.DataPlane"
                 }
               }
             },
@@ -24639,6 +27044,85 @@
           }
         },
         "summary": "Restart Data Plane Agent",
+        "tags": [
+          "DataPlane"
+        ]
+      }
+    },
+    "/dataplanes/dataplanes/{dataPlaneId}/upgrade": {
+      "patch": {
+        "operationId": "upgradeAgent",
+        "parameters": [
+          {
+            "description": "Id of the Data Plane",
+            "in": "path",
+            "name": "dataPlaneId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "#/components/schemas/domino.dataplane.DataPlane"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Upgrade Data Plane Agent",
+        "tags": [
+          "DataPlane"
+        ]
+      }
+    },
+    "/dataplanes/targetVersion": {
+      "get": {
+        "operationId": "getTargetDataPlaneVersion",
+        "parameters": null,
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.dataplane.TargetDataPlaneVersionDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get target Data Plane version",
         "tags": [
           "DataPlane"
         ]
@@ -24683,7 +27167,7 @@
     },
     "/datasetUi/collections": {
       "post": {
-        "operationId": "createDatasetCollection",
+        "operationId": "createDataset",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -24841,7 +27325,7 @@
     },
     "/datasetUi/collections/{datasetId}": {
       "post": {
-        "operationId": "updateDatasetUi",
+        "operationId": "updateDataset",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -24991,7 +27475,7 @@
     },
     "/datasetUi/collections/{datasetId}/snapshot/file": {
       "post": {
-        "operationId": "uploadSnapshotFileUi",
+        "operationId": "uploadSnapshotFile",
         "parameters": [
           {
             "in": "path",
@@ -25144,13 +27628,7 @@
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.dataset.api.DatasetSnapshotDto"
-                }
-              }
-            },
+            "$ref": "#/components/schemas/domino.dataset.api.DatasetSnapshotDto",
             "description": "the new snapshot"
           },
           "400": {
@@ -25354,7 +27832,7 @@
     },
     "/datasetUi/collections/{datasetId}/snapshots": {
       "get": {
-        "operationId": "getSnapshotsUi",
+        "operationId": "getSnapshots",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -25908,7 +28386,7 @@
     },
     "/datasetUi/project/{projectId}/canAddDataset": {
       "get": {
-        "operationId": "canAddDatasetUi",
+        "operationId": "canAddDataset",
         "parameters": [
           {
             "description": "Project identifier",
@@ -26338,7 +28816,7 @@
     },
     "/datasetUi/{snapshotId}": {
       "get": {
-        "operationId": "getSnapshotUi",
+        "operationId": "getSnapshot",
         "parameters": [
           {
             "description": "Id of the snapshot",
@@ -26584,6 +29062,7 @@
           "200": {
             "content": {
               "application/json": {
+                "required": false,
                 "schema": {
                   "type": "number"
                 }
@@ -26605,6 +29084,51 @@
           }
         },
         "summary": "Gets the unit cost of a Dataset (in dollars per Gb per month)",
+        "tags": [
+          "DatasetRw"
+        ]
+      }
+    },
+    "/datasetrw/dataset/enforce-limit/{projectId}": {
+      "get": {
+        "operationId": "shouldEnforceLimits",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get whether a project should enforce dataset limits",
         "tags": [
           "DatasetRw"
         ]
@@ -27285,7 +29809,7 @@
     },
     "/datasetrw/dataset/{datasetId}/tag": {
       "post": {
-        "operationId": "addDatasetTag",
+        "operationId": "addTag",
         "parameters": [
           {
             "description": "Dataset ID",
@@ -27341,7 +29865,7 @@
     },
     "/datasetrw/dataset/{datasetId}/tag/{tagName}": {
       "delete": {
-        "operationId": "removeDatasetTag",
+        "operationId": "removeTag",
         "parameters": [
           {
             "description": "Dataset ID",
@@ -27612,7 +30136,7 @@
     },
     "/datasetrw/datasets/limit/{projectId}": {
       "post": {
-        "operationId": "setDatasetLimitOverride",
+        "operationId": "setLimitOverride",
         "parameters": [
           {
             "description": "Id of the project",
@@ -27963,7 +30487,7 @@
     },
     "/datasetrw/datasets/{datasetId}/snapshot/file/cancel/{uploadKey}": {
       "get": {
-        "operationId": "cancelDatasetSnapshotUpload",
+        "operationId": "cancelSnapshotUpload",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -28010,7 +30534,7 @@
     },
     "/datasetrw/datasets/{datasetId}/snapshot/file/end/{uploadKey}": {
       "get": {
-        "operationId": "endDatasetSnapshotUpload",
+        "operationId": "endSnapshotUpload",
         "parameters": [
           {
             "in": "path",
@@ -28062,7 +30586,7 @@
     },
     "/datasetrw/datasets/{datasetId}/snapshot/file/start": {
       "post": {
-        "operationId": "startDatasetSnapshotUpload",
+        "operationId": "startSnapshotUpload",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -28201,7 +30725,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -28300,7 +30824,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -28363,7 +30887,7 @@
     },
     "/datasetrw/marked-snapshots": {
       "delete": {
-        "operationId": "deleteDatasetMarkedSnapshots",
+        "operationId": "deleteMarkedSnapshots",
         "responses": {
           "200": {
             "content": {
@@ -28853,7 +31377,7 @@
     },
     "/datasetrw/snapshot/upload/{uploadKey}": {
       "get": {
-        "operationId": "getDatasetSnapshotUploadSession",
+        "operationId": "getSnapshotUploadSession",
         "parameters": [
           {
             "in": "path",
@@ -28896,7 +31420,7 @@
     },
     "/datasetrw/snapshot/{snapshotId}": {
       "delete": {
-        "operationId": "deleteDatasetSnapshot",
+        "operationId": "deleteSnapshot",
         "parameters": [
           {
             "description": "Snapshot ID",
@@ -28982,7 +31506,7 @@
         ]
       },
       "put": {
-        "operationId": "updateDatasetSnapshotStatus",
+        "operationId": "updateSnapshotStatus",
         "parameters": [
           {
             "description": "Id of the dataset snapshot to be updated",
@@ -29585,8 +32109,7 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "format": "binary",
-                  "type": "string"
+                  "type": "binary"
                 }
               }
             },
@@ -29764,7 +32287,7 @@
     },
     "/datasetrw/snapshots/summary/{datasetId}": {
       "get": {
-        "operationId": "getDatasetSnapshotSummaries",
+        "operationId": "getSnapshotSummaries",
         "parameters": [
           {
             "description": "Dataset ID",
@@ -29880,6 +32403,7 @@
           "200": {
             "content": {
               "application/json": {
+                "required": true,
                 "schema": {
                   "items": {
                     "$ref": "#/components/schemas/domino.datasetrw.api.DatasetStorageUsageDto"
@@ -29927,6 +32451,7 @@
           "200": {
             "content": {
               "application/json": {
+                "required": false,
                 "schema": {
                   "$ref": "#/components/schemas/domino.datasetrw.api.DatasetStorageUsageDto"
                 }
@@ -30095,7 +32620,7 @@
         ]
       },
       "post": {
-        "operationId": "createDataSource",
+        "operationId": "create",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -30133,6 +32658,160 @@
           }
         },
         "summary": "Create data source",
+        "tags": [
+          "DataSource"
+        ]
+      }
+    },
+    "/datasource/audit": {
+      "get": {
+        "operationId": "getDataSourcesAccessedInRuns",
+        "parameters": [
+          {
+            "description": "the ids of the runs to query datasources from",
+            "in": "query",
+            "name": "runIds",
+            "required": true,
+            "schema": {
+              "items": {
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.datasource.web.DataSourcesAccessedInRunResponse"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get datasources accessed in runs",
+        "tags": [
+          "DataSource"
+        ]
+      }
+    },
+    "/datasource/audit/download": {
+      "get": {
+        "operationId": "downloadDataSourceAuditData",
+        "parameters": [
+          {
+            "description": "if true output will be json file, else txt",
+            "in": "query",
+            "name": "jsonFile",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "binary"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Download DataSource Audit Data for past 6 months",
+        "tags": [
+          "DataSource"
+        ]
+      }
+    },
+    "/datasource/audit/download/runs": {
+      "get": {
+        "operationId": "downloadDataSourceAuditDataInRuns",
+        "parameters": [
+          {
+            "description": "the ids of the runs to query datasources from",
+            "in": "query",
+            "name": "runIds",
+            "required": true,
+            "schema": {
+              "items": {
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "if true output will be json file, else txt",
+            "in": "query",
+            "name": "jsonFile",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/jsonl": {
+                "schema": {
+                  "type": "binary"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Download DataSource Audit Data accessed in Domino runs",
         "tags": [
           "DataSource"
         ]
@@ -30186,7 +32865,7 @@
     },
     "/datasource/auths/all": {
       "get": {
-        "operationId": "getDataSourceAuthConfigs",
+        "operationId": "getAuthConfigs",
         "parameters": [],
         "responses": {
           "200": {
@@ -30398,7 +33077,7 @@
     },
     "/datasource/full": {
       "get": {
-        "operationId": "getDataSourceFullCredentials",
+        "operationId": "getFullCredentials",
         "parameters": [
           {
             "description": "registered data source id",
@@ -30507,64 +33186,6 @@
           }
         },
         "summary": "Get all credentials by data source name and user name",
-        "tags": [
-          "DataSource"
-        ]
-      }
-    },
-    "/datasource/info/user/{userId}": {
-      "get": {
-        "operationId": "getDataSourcesByUserForExecutor",
-        "parameters": [
-          {
-            "description": "User ID",
-            "in": "path",
-            "name": "userId",
-            "required": true,
-            "schema": {
-              "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "description": "DataPlane ID",
-            "in": "query",
-            "name": "dataPlaneId",
-            "required": false,
-            "schema": {
-              "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.datasource.api.DataSourceMetadataDto"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "success"
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "500": {
-            "$ref": "#/components/responses/InternalError"
-          }
-        },
-        "summary": "Get data sources info by user (used by executor)",
         "tags": [
           "DataSource"
         ]
@@ -30802,51 +33423,6 @@
           }
         },
         "summary": "Get whether the user is allowed to see project-specific and datasource-involved data but only with project context",
-        "tags": [
-          "DataSource"
-        ]
-      }
-    },
-    "/datasource/project/{projectId}/notification": {
-      "get": {
-        "operationId": "shouldNotificationBubbleAppear",
-        "parameters": [
-          {
-            "description": "Project Id",
-            "in": "path",
-            "name": "projectId",
-            "required": true,
-            "schema": {
-              "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "description": "success"
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "500": {
-            "$ref": "#/components/responses/InternalError"
-          }
-        },
-        "summary": "Get whether notification bubble in workspace pane appears (new datasources added to project in last week)",
         "tags": [
           "DataSource"
         ]
@@ -31307,6 +33883,55 @@
           }
         },
         "summary": "Get data source",
+        "tags": [
+          "DataSource"
+        ]
+      }
+    },
+    "/datasource/{dataSourceId}/access": {
+      "post": {
+        "operationId": "recordDataSourceAccess",
+        "parameters": [
+          {
+            "description": "accessed data source id",
+            "in": "path",
+            "name": "dataSourceId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.datasource.web.RecordDataSourceAccessRequest"
+              }
+            }
+          },
+          "description": "body with username and runid of access to record",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Record access to datasource from an execution",
         "tags": [
           "DataSource"
         ]
@@ -31853,7 +34478,7 @@
     },
     "/datasource/{dataSourceId}/projects/{projectId}": {
       "delete": {
-        "operationId": "removeProjectFromDataSource",
+        "operationId": "removeProject",
         "parameters": [
           {
             "description": "Data source Id",
@@ -31906,7 +34531,7 @@
         ]
       },
       "post": {
-        "operationId": "addProjectToDataSource",
+        "operationId": "addProject",
         "parameters": [
           {
             "description": "Data source Id",
@@ -32069,7 +34694,7 @@
     },
     "/datasource/{dataSourceId}/users": {
       "delete": {
-        "operationId": "removeUsersFromDataSource",
+        "operationId": "removeUsers",
         "parameters": [
           {
             "description": "Data source Id",
@@ -32125,7 +34750,7 @@
         ]
       },
       "post": {
-        "operationId": "addUsersToDataSource",
+        "operationId": "addUsers",
         "parameters": [
           {
             "description": "Data source Id",
@@ -32181,7 +34806,7 @@
         ]
       },
       "put": {
-        "operationId": "updateUsersForDataSource",
+        "operationId": "updateUsers",
         "parameters": [
           {
             "description": "data source id",
@@ -32235,6 +34860,51 @@
         ]
       }
     },
+    "/environments": {
+      "post": {
+        "operationId": "createEnvironment",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.environments.api.CreateNewEnvironment"
+              }
+            }
+          },
+          "description": "JSON object with environment data to create a new environment",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.environments.api.EnvironmentDetails"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Create environment",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
     "/environments/defaultEnvironment": {
       "get": {
         "operationId": "getDefaultEnvironment",
@@ -32269,10 +34939,65 @@
         ]
       }
     },
+    "/environments/environmentRevision/{environmentRevisionId}": {
+      "get": {
+        "operationId": "getEnvironmentRevisionDetailsViewModel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "environmentRevisionId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.environments.api.EnvironmentRevisionDetails"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get environment revision",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
     "/environments/permissions/all": {
       "get": {
         "operationId": "getEnvironmentPermissions",
-        "parameters": [],
+        "parameters": [
+          {
+            "description": "Domino id of the environment",
+            "in": "query",
+            "name": "environmentId",
+            "required": false,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -32311,6 +35036,16 @@
             "description": "Whether to only get restricted environments or not",
             "in": "query",
             "name": "isRestricted",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Whether to only get environments with an active revision",
+            "in": "query",
+            "name": "getOnlyActiveRevisions",
             "required": false,
             "schema": {
               "nullable": true,
@@ -32359,6 +35094,18 @@
         "operationId": "setDefaultEnvironment",
         "parameters": [],
         "requestBody": {
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
           "content": {
             "application/json": {
               "schema": {
@@ -32369,7 +35116,41 @@
           "description": "The ID of the environment to set as the deployment default",
           "required": true
         },
+        "summary": "Set default environment",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
+    "/environments/{environmentId}": {
+      "delete": {
+        "operationId": "archiveEnvironment",
+        "parameters": [
+          {
+            "description": "Domino id of the environment to archive",
+            "in": "path",
+            "name": "environmentId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.environments.api.EnvironmentDetails"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
+          "204": {
+            "description": "success"
+          },
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
@@ -32383,13 +35164,11 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Set default environment",
+        "summary": "Archive an Environment, removing it from the list of visible environments.",
         "tags": [
           "Environments"
         ]
-      }
-    },
-    "/environments/{environmentId}": {
+      },
       "get": {
         "operationId": "getEnvironmentById",
         "parameters": [
@@ -32482,6 +35261,107 @@
         ]
       }
     },
+    "/environments/{environmentId}/duplicate": {
+      "post": {
+        "operationId": "duplicateEnvironment",
+        "parameters": [
+          {
+            "description": "Id of the environment to duplicate",
+            "in": "path",
+            "name": "environmentId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.environments.api.EnvironmentDetails"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Duplicate environment",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
+    "/environments/{environmentId}/environmentRevision": {
+      "post": {
+        "operationId": "createEnvironmentRevision",
+        "parameters": [
+          {
+            "description": "Domino id of the environment to create revision",
+            "in": "path",
+            "name": "environmentId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.environments.api.NewEnvironmentRevision"
+              }
+            }
+          },
+          "description": "JSON object with environmentrevision data to create a new environment revision",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.environments.api.EnvironmentRevisionDetails"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Create environment revision",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
     "/environments/{environmentId}/environmentRevision/{environmentRevisionId}": {
       "patch": {
         "operationId": "updateEnvironmentRevisionIsRestricted",
@@ -32535,6 +35415,54 @@
           }
         },
         "summary": "Update isRestricted for environments if user has EnvironmentClassifier role",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
+    "/environments/{environmentId}/environmentRevision/{environmentRevisionId}/cancel": {
+      "post": {
+        "operationId": "killRevisionBuild",
+        "parameters": [
+          {
+            "description": "Domino id of the environment",
+            "in": "path",
+            "name": "environmentId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Domino id of the environment revision",
+            "in": "path",
+            "name": "environmentRevisionId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Cancel build for environment revision",
         "tags": [
           "Environments"
         ]
@@ -32671,6 +35599,102 @@
         ]
       }
     },
+    "/environments/{environmentId}/setactive": {
+      "post": {
+        "operationId": "setActiveRevision",
+        "parameters": [
+          {
+            "description": "Domino id of the environment",
+            "in": "path",
+            "name": "environmentId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Domino id of the environment revision",
+            "in": "query",
+            "name": "revisionId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Set the active revision for an environment. If no revision Id is specified, active revision is set to the latest successfully built revision",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
+    "/environments/{environmentId}/visibility": {
+      "post": {
+        "operationId": "updateEnvironmentVisibility",
+        "parameters": [
+          {
+            "description": "Domino id of the environment",
+            "in": "path",
+            "name": "environmentId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.environments.api.VisibilityUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Update the visibility of an environment",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
     "/executions/{executionId}/events": {
       "get": {
         "operationId": "getExecutionEvents",
@@ -32693,7 +35717,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -32704,7 +35728,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -32715,7 +35739,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -32827,7 +35851,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -32838,7 +35862,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -32849,7 +35873,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -34740,7 +37764,7 @@
     },
     "/frontend/snippets": {
       "get": {
-        "operationId": "listFrontendSnippets",
+        "operationId": "list",
         "parameters": [],
         "responses": {
           "200": {
@@ -34771,7 +37795,7 @@
     },
     "/gateway/projects": {
       "get": {
-        "operationId": "listProjects",
+        "operationId": "list",
         "parameters": [
           {
             "description": "The relationship between the current user and the projects to be returned",
@@ -35005,6 +38029,16 @@
               "nullable": true,
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "nullable": true,
+              "type": "number"
+            }
           }
         ],
         "responses": {
@@ -35035,6 +38069,80 @@
           }
         },
         "summary": "searches for the specified terms in the relevant areas with a limit on the number of results",
+        "tags": [
+          "Gateway",
+          "Search"
+        ]
+      }
+    },
+    "/gateway/search-page": {
+      "get": {
+        "operationId": "searchForPage",
+        "parameters": [
+          {
+            "description": "Search term.",
+            "in": "query",
+            "name": "query",
+            "required": true,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "area",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "nullable": true,
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "timestampFormat",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.common.gateway.search.SearchPageGatewayDTO"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "provides search results for search page. has the same functionality as /search but returns more details for the selected area",
         "tags": [
           "Gateway",
           "Search"
@@ -35110,7 +38218,7 @@
                 "bitbucket",
                 "bitbucketServer"
               ],
-              "type": "string"
+              "type": "#/components/schemas/domino.repoman.domain.GitProviderName"
             }
           },
           {
@@ -35180,7 +38288,7 @@
                 "bitbucket",
                 "bitbucketServer"
               ],
-              "type": "string"
+              "type": "#/components/schemas/domino.repoman.domain.GitProviderName"
             }
           },
           {
@@ -35190,7 +38298,7 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
+              "type": "#/components/schemas/domino.common.DominoId"
             }
           }
         ],
@@ -35199,7 +38307,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/domino.projects.api.repositories.responses.GitApiResponseWrapper"
+                  "$ref": "#/components/schemas/domino.projects.api.repositories.responses.GitApiResponseWrapper[domino.gitproviders.api.GetOwnersApiResponse]"
                 }
               }
             },
@@ -35241,7 +38349,7 @@
                 "bitbucket",
                 "bitbucketServer"
               ],
-              "type": "string"
+              "type": "#/components/schemas/domino.repoman.domain.GitProviderName"
             }
           },
           {
@@ -35251,7 +38359,7 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
+              "type": "#/components/schemas/domino.common.DominoId"
             }
           },
           {
@@ -35507,7 +38615,7 @@
             "required": false,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
+              "type": "domino.common.DominoId"
             }
           }
         ],
@@ -35562,7 +38670,7 @@
             "required": false,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
+              "type": "domino.common.DominoId"
             }
           }
         ],
@@ -35729,7 +38837,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "type": "string"
           },
           {
             "description": "Id of the project",
@@ -35739,7 +38848,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "description": "Command parameters that needs to be passed to the job",
@@ -35748,7 +38858,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "type": "string"
           }
         ],
         "responses": {
@@ -35822,7 +38933,7 @@
     },
     "/jobs/events": {
       "get": {
-        "operationId": "getJobEvents",
+        "operationId": "notFound",
         "responses": {
           "200": {
             "content": {
@@ -35856,7 +38967,7 @@
     },
     "/jobs/getStatus/values": {
       "get": {
-        "operationId": "getJobStatusValues",
+        "operationId": "getStatus",
         "parameters": [],
         "responses": {
           "200": {
@@ -35905,14 +39016,10 @@
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.jobs.interface.ArtifactsInfoDto"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "$ref": "#/components/schemas/domino.jobs.interface.ArtifactsInfoDto"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -36007,14 +39114,10 @@
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.jobs.interface.CodeInfoDto"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "$ref": "#/components/schemas/domino.jobs.interface.CodeInfoDto"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -36543,7 +39646,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -36588,7 +39692,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -36623,7 +39728,7 @@
     },
     "/jobs/{jobId}/computeClusterFileSyncStatus": {
       "get": {
-        "operationId": "getJobComputeClusterFileSyncStatus",
+        "operationId": "getComputeClusterFileSyncStatus",
         "parameters": [
           {
             "description": "ID of the job",
@@ -36633,7 +39738,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -36668,7 +39774,7 @@
     },
     "/jobs/{jobId}/computeClusterStatus": {
       "get": {
-        "operationId": "getJobComputeClusterStatus",
+        "operationId": "getComputeClusterStatus",
         "parameters": [
           {
             "description": "ID of the job",
@@ -36678,7 +39784,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -36786,7 +39893,7 @@
     },
     "/jobs/{jobId}/linkJobToGoal": {
       "post": {
-        "operationId": "linkSingleJobToGoal",
+        "operationId": "linkJobToGoal",
         "parameters": [
           {
             "in": "path",
@@ -37567,7 +40674,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "description": "Type of the cluster to get settings for",
@@ -37946,6 +41054,82 @@
         ]
       }
     },
+    "/mlflow/project/{projectId}": {
+      "get": {
+        "description": "Gets information about a project. Flattens collaborating orgs in the project into list of org members",
+        "operationId": "getProjectForMlflow",
+        "parameters": [
+          {
+            "description": "Id of project to retrieve info about",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.mlflow.api.MlflowProjectInfo"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get project info for use by the mlflow-proxy",
+        "tags": [
+          "MLFlow"
+        ]
+      }
+    },
+    "/mlflow/projectIds": {
+      "get": {
+        "operationId": "getCollaboratingProjectIds",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.common.DominoId"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get ids of projects a user can access for use by the mlflow proxy",
+        "tags": [
+          "MLFlow"
+        ]
+      }
+    },
     "/modelManager/archiveModelExport/{exportId}": {
       "delete": {
         "operationId": "archiveModelExport",
@@ -37975,7 +41159,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Archives model export for a given export id",
+        "summary": "Archives model API export for a given export id",
         "tags": [
           "ModelManager"
         ]
@@ -37983,7 +41167,7 @@
     },
     "/modelManager/buildModelImage": {
       "post": {
-        "operationId": "buildManagerModelImage",
+        "operationId": "buildModelImage",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -37993,19 +41177,15 @@
               }
             }
           },
-          "description": "JSON object with information for building a model image",
+          "description": "JSON object with information for building a model API image",
           "required": true
         },
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.modelmanager.api.ModelBuild"
-                }
-              }
-            },
-            "description": "Request accepted, building of model image continues offline"
+            "description": "Request accepted, building of model API image continues offline",
+            "schema": {
+              "$ref": "#/components/schemas/domino.modelmanager.api.ModelBuild"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -38020,7 +41200,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Build a Model Image",
+        "summary": "Build a Model API Image",
         "tags": [
           "ModelManager"
         ]
@@ -38043,14 +41223,10 @@
         },
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.modelmanager.web.ExportVersionStatusWithoutModelResponse"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of image continues offline"
+            "description": "Request accepted, exporting of image continues offline",
+            "schema": {
+              "$ref": "#/components/schemas/domino.modelmanager.web.ExportVersionStatusWithoutModelResponse"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -38102,19 +41278,15 @@
               }
             }
           },
-          "description": "JSON object with information for exporting a model into the Snowflake Api",
+          "description": "JSON object with information for exporting a model API into the Snowflake API",
           "required": true
         },
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.modelmanager.api.ModelExportVersionStatus"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of model image continues offline"
+            "description": "Request accepted, exporting of model API image continues offline",
+            "schema": {
+              "$ref": "#/components/schemas/domino.modelmanager.api.ModelExportVersionStatus"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -38129,7 +41301,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Export a Model to Snowflake",
+        "summary": "Export a Model API to Snowflake",
         "tags": [
           "ModelManager"
         ]
@@ -38140,7 +41312,7 @@
         "operationId": "getBuildLogs",
         "parameters": [
           {
-            "description": "Id of model to return build logs for.",
+            "description": "Id of model API to return build logs for.",
             "in": "path",
             "name": "modelId",
             "required": true,
@@ -38150,7 +41322,7 @@
             }
           },
           {
-            "description": "Id of the version of the model to return build logs for.",
+            "description": "Id of the version of the model API to return build logs for.",
             "in": "path",
             "name": "modelVersionId",
             "required": true,
@@ -38160,13 +41332,24 @@
             }
           },
           {
-            "description": "build Id of the model to return build logs for.",
+            "description": "build Id of the model API to return build logs for.",
             "in": "query",
             "name": "buildId",
             "required": false,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
+            }
+          },
+          {
+            "description": "The epoch time in nanoseconds to start fetching from, such as \"1543538813745986325\". \"0\" by default and will typically be used for a timestamp-based offset log fetching strategy.",
+            "in": "query",
+            "name": "sinceTimeNano",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "nullable": true,
+              "type": "number"
             }
           }
         ],
@@ -38197,7 +41380,155 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get model image build logs",
+        "summary": "Get model API image build logs. Returns logs as String",
+        "tags": [
+          "ModelManager"
+        ]
+      }
+    },
+    "/modelManager/getBuildLogsV2/{modelId}/{modelVersionId}": {
+      "get": {
+        "operationId": "getBuildLogsV2",
+        "parameters": [
+          {
+            "description": "Id of model API to return build logs for.",
+            "in": "path",
+            "name": "modelId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of the version of the model API to return build logs for.",
+            "in": "path",
+            "name": "modelVersionId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "build Id of the model API to return build logs for.",
+            "in": "query",
+            "name": "buildId",
+            "required": false,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The epoch time in nanoseconds to start fetching from, such as \"1543538813745986325\". \"0\" by default and will typically be used for a timestamp-based offset log fetching strategy.",
+            "in": "query",
+            "name": "sinceTimeNano",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "nullable": true,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.modelmanager.api.ModelBuildLogsV2"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get model API image build logs version 2. Returns logs as LogLine - JSON formatted and detailed metadata",
+        "tags": [
+          "ModelManager"
+        ]
+      }
+    },
+    "/modelManager/getExportLogs/{modelId}/{modelVersionId}": {
+      "get": {
+        "operationId": "getExportLogs",
+        "parameters": [
+          {
+            "description": "Id of model API to return build logs for.",
+            "in": "path",
+            "name": "modelId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of the version of the model API to return build logs for.",
+            "in": "path",
+            "name": "modelVersionId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The epoch time in nanoseconds to start fetching from, such as \"1543538813745986325\". \"0\" by default and will typically be used for a timestamp-based offset log fetching strategy.",
+            "in": "query",
+            "name": "sinceTimeNano",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "nullable": true,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.modelmanager.api.ModelExportLogs"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get model API image export logs",
         "tags": [
           "ModelManager"
         ]
@@ -38244,7 +41575,173 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get model image export version logs",
+        "summary": "Get model API image export version logs",
+        "tags": [
+          "ModelManager"
+        ]
+      }
+    },
+    "/modelManager/getInstanceLogs/{modelId}/{modelVersionId}": {
+      "get": {
+        "operationId": "getInstanceLogs",
+        "parameters": [
+          {
+            "description": "Id of model API to return build logs for.",
+            "in": "path",
+            "name": "modelId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of the version of the model API to return build logs for.",
+            "in": "path",
+            "name": "modelVersionId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The pod name of the model API instance.",
+            "in": "query",
+            "name": "podName",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "The container name of the model API instance.",
+            "in": "query",
+            "name": "containerName",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "The epoch time in nanoseconds to start fetching from, such as \"1543538813745986325\". \"0\" by default and will typically be used for a timestamp-based offset log fetching strategy.",
+            "in": "query",
+            "name": "sinceTimeNano",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "nullable": true,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Whether to fetch from tail or not.",
+            "in": "query",
+            "name": "tail",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "The maximum number of logs to retrieve.",
+            "in": "query",
+            "name": "maxResults",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.modelmanager.api.ModelInstanceLogs"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get model API image instance logs",
+        "tags": [
+          "ModelManager"
+        ]
+      }
+    },
+    "/modelManager/getModelDeploymentLabels/{modelId}/{modelVersionId}": {
+      "get": {
+        "operationId": "getModelDeploymentLabels",
+        "parameters": [
+          {
+            "description": "Id of model API to return deployment labels for.",
+            "in": "path",
+            "name": "modelId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of the version of the model API to return deployment labels for.",
+            "in": "path",
+            "name": "modelVersionId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.modelmanager.api.DeploymentLabels"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get deployment labels for a model API",
         "tags": [
           "ModelManager"
         ]
@@ -38286,7 +41783,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Gets model export for a given export id",
+        "summary": "Gets model API export for a given export id",
         "tags": [
           "ModelManager"
         ]
@@ -38297,7 +41794,7 @@
         "operationId": "getModelExportVersions",
         "parameters": [
           {
-            "description": "Id of the export to get model export versions for.",
+            "description": "Id of the export to get model API export versions for.",
             "in": "path",
             "name": "exportId",
             "required": true,
@@ -38315,7 +41812,7 @@
               "format": "int32",
               "minimum": 0,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -38327,7 +41824,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -38379,7 +41876,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Gets all model export versions for a given export id.",
+        "summary": "Gets all model API export versions for a given export id.",
         "tags": [
           "ModelManager"
         ]
@@ -38390,7 +41887,7 @@
         "operationId": "getModelExportsByProjectId",
         "parameters": [
           {
-            "description": "Id of the project to get model exports for.",
+            "description": "Id of the project to get model API exports for.",
             "in": "path",
             "name": "projectId",
             "required": true,
@@ -38408,7 +41905,7 @@
               "format": "int32",
               "minimum": 0,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -38420,7 +41917,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -38484,7 +41981,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Gets all model exports for a given project id.",
+        "summary": "Gets all model API exports for a given project id.",
         "tags": [
           "ModelManager"
         ]
@@ -38531,7 +42028,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get all models in a project",
+        "summary": "Get all models APIs in a project",
         "tags": [
           "ModelManager"
         ]
@@ -38579,7 +42076,64 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get all models that use a certain domino environment",
+        "summary": "Get all models APIs that use a certain domino environment",
+        "tags": [
+          "ModelManager"
+        ]
+      }
+    },
+    "/modelManager/monitoring/permissions": {
+      "get": {
+        "operationId": "getModelPermissionsForMonitoring",
+        "parameters": [
+          {
+            "description": "User ID to check permissions for.",
+            "in": "query",
+            "name": "userIdToCheckPermissionsFor",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Model IDs to check permissions for.",
+            "in": "query",
+            "name": "modelIds",
+            "required": true,
+            "schema": {
+              "items": {
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.api.responses.ModelPermissionForMonitoringApiResponse"
+              },
+              "type": "array"
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get current user's permissions to inform behavior for monitoring",
         "tags": [
           "ModelManager"
         ]
@@ -38644,7 +42198,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -38656,7 +42210,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -38716,20 +42270,16 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           }
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.modelmanager.api.ModelsForUIApiResponse"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "$ref": "#/components/schemas/domino.modelmanager.api.ModelsForUIApiResponse"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -38744,7 +42294,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get models for display in the UI",
+        "summary": "Get model APIs for display in the UI",
         "tags": [
           "ModelManager"
         ]
@@ -38767,14 +42317,10 @@
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.modelmanager.api.responses.ModelPermissionsForUIApiResponse"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "$ref": "#/components/schemas/domino.modelmanager.api.responses.ModelPermissionsForUIApiResponse"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -38836,7 +42382,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get model's all model versions reproduce in workspace details",
+        "summary": "Get model API's all model API versions reproduce in workspace details",
         "tags": [
           "ModelManager"
         ]
@@ -38883,7 +42429,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get last 24 hour invocation counts for model apis",
+        "summary": "Get last 24 hour invocation counts for model APIs",
         "tags": [
           "ModelManager"
         ]
@@ -38948,7 +42494,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get timeseries of data for model invocation",
+        "summary": "Get timeseries of data for model API invocation",
         "tags": [
           "ModelManager"
         ]
@@ -38959,7 +42505,7 @@
         "operationId": "linkModelToGoal",
         "parameters": [
           {
-            "description": "Domino id of the model version",
+            "description": "Domino id of the model API version",
             "in": "path",
             "name": "modelVersionId",
             "required": true,
@@ -38977,7 +42523,7 @@
               }
             }
           },
-          "description": "JSON object with information for linking model to a goal",
+          "description": "JSON object with information for linking model API to a goal",
           "required": true
         },
         "responses": {
@@ -39007,7 +42553,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Link model to a goal",
+        "summary": "Link model API to a goal",
         "tags": [
           "ModelManager"
         ]
@@ -39092,7 +42638,7 @@
               }
             }
           },
-          "description": "JSON object with information for unlinking model to a goal",
+          "description": "JSON object with information for unlinking model API from a goal",
           "required": true
         },
         "responses": {
@@ -39122,7 +42668,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Unlink model to a goal",
+        "summary": "Unlink model API from a goal",
         "tags": [
           "ModelManager"
         ]
@@ -39716,10 +43262,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           },
           "500": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           }
         },
         "summary": "list top model product views for a given time range",
@@ -40025,7 +43571,7 @@
     },
     "/modelProducts/{modelProductId}/start": {
       "post": {
-        "operationId": "startModelProduct",
+        "operationId": "start",
         "parameters": [
           {
             "in": "path",
@@ -40079,7 +43625,7 @@
     },
     "/modelProducts/{modelProductId}/stop": {
       "post": {
-        "operationId": "stopModelProduct",
+        "operationId": "stop",
         "parameters": [
           {
             "description": "Domino id of the model product (app)",
@@ -40186,10 +43732,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           },
           "500": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           }
         },
         "summary": "get count of views on one model product for a given time range",
@@ -40242,10 +43788,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           },
           "500": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           }
         },
         "summary": "get count of views on one model product for a given time range",
@@ -40324,17 +43870,13 @@
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.common.modelproduct.AppVersionOverview"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.common.modelproduct.AppVersionOverview"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -40435,10 +43977,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           },
           "500": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           }
         },
         "summary": "record a view on a model product",
@@ -40721,7 +44263,6 @@
             }
           }
         ],
-        "responses": {},
         "tags": [
           "photonRawData"
         ]
@@ -41119,7 +44660,7 @@
     },
     "/projectManagement/goal/{goalId}": {
       "delete": {
-        "operationId": "deleteManageProjectGoal",
+        "operationId": "deleteProjectGoal",
         "parameters": [
           {
             "in": "path",
@@ -41169,11 +44710,118 @@
         "tags": [
           "ProjectManagement"
         ]
+      },
+      "get": {
+        "operationId": "getProjectGoal",
+        "parameters": [
+          {
+            "description": "Domino id of the goal to get",
+            "in": "path",
+            "name": "goalId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "type": "domino.common.DominoId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectGoal"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProjectManagementErrorResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get individual project goal",
+        "tags": [
+          "ProjectManagement"
+        ]
+      }
+    },
+    "/projectManagement/goal/{goalId}/assign": {
+      "post": {
+        "operationId": "assignUserToGoal",
+        "parameters": [
+          {
+            "description": "Domino id of the goal",
+            "in": "path",
+            "name": "goalId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "type": "domino.common.DominoId"
+          },
+          {
+            "description": "Domino id of user being assigned to the goal",
+            "in": "query",
+            "name": "assigneeId",
+            "required": false,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "type": "domino.common.DominoId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectGoal"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProjectManagementErrorResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Assign a user to a goal",
+        "tags": [
+          "ProjectManagement"
+        ]
       }
     },
     "/projectManagement/goal/{goalId}/comment": {
       "post": {
-        "operationId": "addManageCommentOnGoal",
+        "operationId": "addCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -41238,7 +44886,7 @@
     },
     "/projectManagement/goal/{goalId}/comment/list": {
       "get": {
-        "operationId": "getManageCommentsOnGoal",
+        "operationId": "getCommentsOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -41302,7 +44950,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -41353,7 +45002,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "description": "Domino id of the project stage",
@@ -41363,7 +45013,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "in": "cookie",
@@ -41408,7 +45059,7 @@
     },
     "/projectManagement/goal/{goalId}/updateDescription": {
       "post": {
-        "operationId": "updateManageProjectGoalDescription",
+        "operationId": "updateProjectGoalDescription",
         "parameters": [
           {
             "in": "path",
@@ -41473,7 +45124,7 @@
     },
     "/projectManagement/goal/{goalId}/updateTitle": {
       "post": {
-        "operationId": "updateManageProjectGoalTitle",
+        "operationId": "updateProjectGoalTitle",
         "parameters": [
           {
             "in": "path",
@@ -41538,7 +45189,7 @@
     },
     "/projectManagement/goalComment/{threadId}/{commentId}": {
       "delete": {
-        "operationId": "archiveManageCommentOnGoal",
+        "operationId": "archiveCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -41599,7 +45250,7 @@
         ]
       },
       "put": {
-        "operationId": "updateManageCommentOnGoal",
+        "operationId": "updateCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -41673,7 +45324,7 @@
     },
     "/projectManagement/goalComment/{threadId}/{commentId}/canUpdate": {
       "get": {
-        "operationId": "canUpdateManageCommentOnGoal",
+        "operationId": "canUpdateCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -41996,7 +45647,7 @@
     },
     "/projectManagement/linkFileToGoal": {
       "post": {
-        "operationId": "linkManageFileToGoalForProject",
+        "operationId": "linkFileToGoal",
         "parameters": [
           {
             "in": "cookie",
@@ -42108,7 +45759,7 @@
     },
     "/projectManagement/project/{projectId}/comment": {
       "post": {
-        "operationId": "addManageCommentOnProject",
+        "operationId": "addCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -42173,7 +45824,7 @@
     },
     "/projectManagement/project/{projectId}/comment/list": {
       "get": {
-        "operationId": "getManageCommentsOnProject",
+        "operationId": "getCommentsOnProject",
         "parameters": [
           {
             "in": "path",
@@ -42237,7 +45888,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -42278,7 +45930,7 @@
     },
     "/projectManagement/projectComment/{threadId}/{commentId}": {
       "delete": {
-        "operationId": "archiveManageCommentOnProject",
+        "operationId": "archiveCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -42339,7 +45991,7 @@
         ]
       },
       "put": {
-        "operationId": "updateManageCommentOnProject",
+        "operationId": "updateCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -42413,7 +46065,7 @@
     },
     "/projectManagement/projectComment/{threadId}/{commentId}/canUpdate": {
       "get": {
-        "operationId": "canUpdateManageCommentOnProject",
+        "operationId": "canUpdateCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -42512,7 +46164,7 @@
     },
     "/projectManagement/unlinkFileFromGoal": {
       "post": {
-        "operationId": "unlinkManageProjectFileFromGoal",
+        "operationId": "unlinkFileFromGoal",
         "parameters": [
           {
             "in": "cookie",
@@ -42670,7 +46322,7 @@
     },
     "/projectManagement/{jobId}/unlinkJobFromGoal": {
       "post": {
-        "operationId": "unlinkManageJobFromGoal",
+        "operationId": "unlinkJobFromGoal",
         "parameters": [
           {
             "in": "path",
@@ -42733,9 +46385,64 @@
         ]
       }
     },
+    "/projectManagement/{projectId}/archiveProjectGoalStage": {
+      "delete": {
+        "operationId": "archiveProjectGoalStage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projectManagement.web.ArchiveProjectGoalStage"
+              }
+            }
+          },
+          "description": "JSON object with data to create a goal stage",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectStage"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Archive a goal stage",
+        "tags": [
+          "ProjectManagement"
+        ]
+      }
+    },
     "/projectManagement/{projectId}/createGoal": {
       "post": {
-        "operationId": "createManageProjectGoal",
+        "operationId": "createProjectGoal",
         "parameters": [
           {
             "in": "path",
@@ -42798,6 +46505,61 @@
         ]
       }
     },
+    "/projectManagement/{projectId}/createProjectGoalStage": {
+      "post": {
+        "operationId": "createProjectGoalStage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projectManagement.web.CreateProjectGoalStage"
+              }
+            }
+          },
+          "description": "JSON object with data to create a goal stage",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectStage"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Create goal stages",
+        "tags": [
+          "ProjectManagement"
+        ]
+      }
+    },
     "/projectManagement/{projectId}/fullSyncStatus": {
       "get": {
         "operationId": "getFullSyncStatus",
@@ -42810,7 +46572,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -42858,7 +46621,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -42909,7 +46673,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -42947,7 +46712,7 @@
     },
     "/projectManagement/{projectId}/goals": {
       "get": {
-        "operationId": "getManageProjectGoals",
+        "operationId": "getProjectGoals",
         "parameters": [
           {
             "in": "path",
@@ -42966,6 +46731,72 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.projects.api.ProjectGoal"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProjectManagementErrorResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get project goals",
+        "tags": [
+          "ProjectManagement"
+        ]
+      },
+      "post": {
+        "operationId": "getFilteredProjectGoals",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "X-Domino-PmApiToken",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projectManagement.web.FilterProjectGoals"
+              }
+            }
+          },
+          "description": "JSON object with data to filter project goals",
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {
@@ -43023,7 +46854,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "in": "query",
@@ -43074,6 +46906,66 @@
         ]
       }
     },
+    "/projectManagement/{projectId}/projectGoalStages": {
+      "get": {
+        "operationId": "getProjectGoalStages",
+        "parameters": [
+          {
+            "description": "Domino id of the project to get goal stages from",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "type": "domino.common.DominoId"
+          },
+          {
+            "description": "Include archived stages in the results",
+            "in": "query",
+            "name": "includeArchived",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "type": "Boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.projects.api.ProjectStage"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get all project goal stages on a project.",
+        "tags": [
+          "ProjectManagement"
+        ]
+      }
+    },
     "/projectManagement/{projectId}/unlinkAndResetProject": {
       "post": {
         "operationId": "unlinkAndResetProject",
@@ -43086,7 +46978,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -43127,7 +47020,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "in": "query",
@@ -43178,9 +47072,64 @@
         ]
       }
     },
+    "/projectManagement/{projectId}/updateProjectGoalStage": {
+      "post": {
+        "operationId": "updateProjectGoalStage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projectManagement.web.UpdateProjectGoalStage"
+              }
+            }
+          },
+          "description": "JSON object with data to create a goal stage",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectStage"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Update name of existing goal stage",
+        "tags": [
+          "ProjectManagement"
+        ]
+      }
+    },
     "/projectManagement/{workspaceId}/linkWorkspaceToGoal": {
       "post": {
-        "operationId": "linkManageWorkspaceToGoal",
+        "operationId": "linkWorkspaceToGoal",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -43190,7 +47139,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "in": "cookie",
@@ -43246,7 +47196,7 @@
     },
     "/projectManagement/{workspaceId}/unlinkWorkspaceFromGoal": {
       "post": {
-        "operationId": "unlinkManageWorkspaceFromGoal",
+        "operationId": "unlinkWorkspaceFromGoal",
         "parameters": [
           {
             "in": "path",
@@ -43361,7 +47311,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "type": "String"
           },
           {
             "description": "Id of the project",
@@ -43371,7 +47322,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -43392,7 +47344,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "retrieves the project to be used for Actionable Insights for a Model",
+        "summary": "retrieves the project to be used for Actionable Insights for a Model API",
         "tags": [
           "ActionableInsights"
         ]
@@ -43438,7 +47390,7 @@
     },
     "/projects/dontCall": {
       "get": {
-        "operationId": "getProjectStatuses",
+        "operationId": "notFound",
         "responses": {
           "200": {
             "content": {
@@ -43472,6 +47424,17 @@
     "/projects/permissions/all": {
       "get": {
         "operationId": "getProjectPermissions",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "projectId",
+            "required": false,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -44043,7 +48006,7 @@
     },
     "/projects/portfolio/moveProjectToStage": {
       "post": {
-        "operationId": "movePortfolioProjectToStage",
+        "operationId": "moveProjectToStage",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -44218,6 +48181,98 @@
         "summary": "Archive comment on Goal",
         "tags": [
           "Projects"
+        ]
+      }
+    },
+    "/projects/templates/projectHubTemplates": {
+      "get": {
+        "operationId": "getProjectHubTemplates",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.projects.api.ProjectHubTemplatesResult"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get the project hub templates for a deployment",
+        "tags": [
+          "Projects",
+          "Templates"
+        ]
+      }
+    },
+    "/projects/templates/{templateId}": {
+      "get": {
+        "operationId": "getProjectHubTemplate",
+        "parameters": [
+          {
+            "description": "String of the template's id",
+            "in": "path",
+            "name": "templateId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "string of the template's revision id",
+            "in": "query",
+            "name": "revisionId",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectHubTemplateResult"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get a single project hub template for a deployment",
+        "tags": [
+          "Projects",
+          "Templates"
         ]
       }
     },
@@ -44454,6 +48509,59 @@
       }
     },
     "/projects/{projectId}/collaborators": {
+      "get": {
+        "operationId": "getProjectCollaborators",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return only users and org members.",
+            "in": "query",
+            "name": "getUsers",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.common.user.Person"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Retrieves all of the collaborators in a project",
+        "tags": [
+          "Projects"
+        ]
+      },
       "post": {
         "operationId": "addCollaborator",
         "parameters": [
@@ -44721,7 +48829,7 @@
     },
     "/projects/{projectId}/comments": {
       "get": {
-        "operationId": ";ostCommentsOnProject",
+        "operationId": "getCommentsOnProject",
         "parameters": [
           {
             "description": "Domino id of the project",
@@ -45304,7 +49412,7 @@
     },
     "/projects/{projectId}/environmentVariables": {
       "get": {
-        "operationId": "listProjectEnvironmentVariables",
+        "operationId": "getProjectEnvironmentVariables",
         "parameters": [
           {
             "in": "path",
@@ -45321,7 +49429,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/domino.common.models.EnvironmentVariables"
+                  "items": {
+                    "$ref": "#/components/schemas/domino.common.models.EnvironmentVariable"
+                  },
+                  "type": "array"
                 }
               }
             },
@@ -45346,7 +49457,7 @@
         ]
       },
       "post": {
-        "operationId": "setProjectEnvironmentVariables",
+        "operationId": "upsertProjectEnvironmentVariable",
         "parameters": [
           {
             "description": "Id of the project to add environment variables",
@@ -45363,7 +49474,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/domino.common.models.EnvironmentVariables"
+                "$ref": "#/components/schemas/domino.common.models.EnvironmentVariable"
               }
             }
           },
@@ -45374,7 +49485,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/domino.common.models.EnvironmentVariables"
+                  "$ref": "#/components/schemas/domino.common.models.EnvironmentVariable"
                 }
               }
             },
@@ -45394,6 +49505,53 @@
           }
         },
         "summary": "sets the specified project's environment variables",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/environmentVariables/{environmentVariableName}": {
+      "delete": {
+        "operationId": "deleteProjectEnvironmentVariable",
+        "parameters": [
+          {
+            "description": "Id of the project to remove environment variables",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "name of the environment variable to remove",
+            "in": "path",
+            "name": "environmentVariableName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "deletes the environment variable from the specified project",
         "tags": [
           "Projects"
         ]
@@ -45773,7 +49931,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -45786,7 +49944,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -46511,54 +50669,6 @@
         ]
       }
     },
-    "/projects/{projectId}/goals": {
-      "get": {
-        "operationId": "getProjectGoals",
-        "parameters": [
-          {
-            "description": "Domino id of the project",
-            "in": "path",
-            "name": "projectId",
-            "required": true,
-            "schema": {
-              "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.projects.api.ProjectGoal"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "success"
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "500": {
-            "$ref": "#/components/responses/InternalError"
-          }
-        },
-        "summary": "Get project goals",
-        "tags": [
-          "Projects"
-        ]
-      }
-    },
     "/projects/{projectId}/hardwareTiers": {
       "get": {
         "operationId": "listHardwareTiersForProject",
@@ -46577,6 +50687,16 @@
             "description": "Flag to declare if archived hardware tiers are included in the response.",
             "in": "query",
             "name": "showArchived",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Flag to declare if only model api hardware tiers are returned in the response.",
+            "in": "query",
+            "name": "forModelApi",
             "required": false,
             "schema": {
               "nullable": true,
@@ -46655,7 +50775,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/domino.common.DominoId"
                 }
               }
             },
@@ -46808,7 +50928,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/domino.common.DominoId"
                 }
               }
             },
@@ -47706,7 +51826,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -47779,7 +51899,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -47852,7 +51972,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -47916,7 +52036,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -48100,6 +52220,7 @@
           "200": {
             "content": {
               "application/json": {
+                "required": false,
                 "schema": {
                   "$ref": "#/components/schemas/domino.quota.api.QuotaDto"
                 }
@@ -48433,7 +52554,7 @@
     },
     "/tags": {
       "get": {
-        "operationId": "listTags",
+        "operationId": "list",
         "parameters": [
           {
             "description": "Optional filter for a tag by name",
@@ -48779,14 +52900,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "type": "boolean"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -48819,21 +52936,15 @@
             "in": "header",
             "name": "X-Domino-Api-Key",
             "required": false,
-            "schema": {
-              "type": "string"
-            }
+            "type": "string"
           }
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.common.user.LiteUserResponseDTO"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "$ref": "#/components/schemas/domino.common.user.LiteUserResponseDTO"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -48898,6 +53009,7 @@
             }
           },
           {
+            "default": "created",
             "description": "Specify sort criteria (optional, incompatible with defaultSort=true)",
             "in": "query",
             "name": "sort",
@@ -48916,6 +53028,7 @@
             }
           },
           {
+            "default": "desc",
             "description": "Specify sort direction (optional, incompatible with defaultSort=true)",
             "in": "query",
             "name": "dir",
@@ -48930,6 +53043,7 @@
             }
           },
           {
+            "default": false,
             "description": "If true, use the frontend's default sorting and return 400 if either 'sort' or 'dir' are set.",
             "in": "query",
             "name": "defaultSort",
@@ -49368,22 +53482,18 @@
               }
             }
           },
-          "description": "JSON object with information for building a model image",
+          "description": "JSON object with information for building a model API image",
           "required": true
         },
         "responses": {
           "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.modelmanager.web.BuildModelImageApiResponse"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Request accepted, building of model image continues offline"
+            "description": "Request accepted, building of model API image continues offline",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.web.BuildModelImageApiResponse"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -49398,7 +53508,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Build a Model Image",
+        "summary": "Build a Model API Image",
         "tags": [
           "ModelManager"
         ]
@@ -49445,7 +53555,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get model image export status",
+        "summary": "Get model API image export status",
         "tags": [
           "ModelManager"
         ]
@@ -49453,7 +53563,7 @@
     },
     "/v4/models/{exportId}/getExportLogs": {
       "get": {
-        "operationId": "getModelExportVersionLogs",
+        "operationId": "getExportVersionLogs",
         "parameters": [
           {
             "in": "path",
@@ -49492,7 +53602,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get model image export logs",
+        "summary": "Get model API image export logs",
         "tags": [
           "ModelManager"
         ]
@@ -49529,22 +53639,18 @@
               }
             }
           },
-          "description": "JSON object with information for exporting a model image",
+          "description": "JSON object with information for exporting a model API image",
           "required": true
         },
         "responses": {
           "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of model image continues offline"
+            "description": "Request accepted, exporting of model API image continues offline",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -49559,7 +53665,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Export a Model Image to NVIDIA Fleet command [BETA]",
+        "summary": "Export a Model API Image to NVIDIA Fleet command [BETA]",
         "tags": [
           "ModelManager"
         ]
@@ -49596,22 +53702,18 @@
               }
             }
           },
-          "description": "JSON object with information for exporting a model image",
+          "description": "JSON object with information for exporting a model API image",
           "required": true
         },
         "responses": {
           "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of model image continues offline"
+            "description": "Request accepted, exporting of model API image continues offline",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -49626,7 +53728,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Export a Model Image",
+        "summary": "Export a Model API Image",
         "tags": [
           "ModelManager"
         ]
@@ -49634,7 +53736,7 @@
     },
     "/v4/models/{modelId}/{modelVersionId}/exportImageForSnowflake": {
       "post": {
-        "operationId": "exportModelImageForSnowflake",
+        "operationId": "exportImageForSnowflake",
         "parameters": [
           {
             "in": "path",
@@ -49663,22 +53765,18 @@
               }
             }
           },
-          "description": "JSON object with information for exporting a model into the Snowflake Api",
+          "description": "JSON object with information for exporting a model API into the Snowflake Api",
           "required": true
         },
         "responses": {
           "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of model image continues offline"
+            "description": "Request accepted, exporting of model API image continues offline",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -49693,7 +53791,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Export a Model to Snowflake",
+        "summary": "Export a Model API to Snowflake",
         "tags": [
           "ModelManager"
         ]
@@ -49730,22 +53828,18 @@
               }
             }
           },
-          "description": "JSON object with information for exporting a model image",
+          "description": "JSON object with information for exporting a model API image",
           "required": true
         },
         "responses": {
           "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of model image continues offline"
+            "description": "Request accepted, exporting of model API image continues offline",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -49760,7 +53854,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Export a Model Image",
+        "summary": "Export a Model API Image",
         "tags": [
           "ModelManager"
         ]
@@ -49768,7 +53862,7 @@
     },
     "/v4/models/{modelId}/{modelVersionId}/getBuildLogs": {
       "get": {
-        "operationId": "getModelBuildLogs",
+        "operationId": "getBuildLogs",
         "parameters": [
           {
             "in": "path",
@@ -49816,7 +53910,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get model image build logs",
+        "summary": "Get model API image build logs",
         "tags": [
           "ModelManager"
         ]
@@ -49872,7 +53966,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get model build status",
+        "summary": "Get model API image build status",
         "tags": [
           "ModelManager"
         ]
@@ -49928,7 +54022,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get deployment status for a model version",
+        "summary": "Get deployment status for a model API version",
         "tags": [
           "ModelManager"
         ]
@@ -49984,7 +54078,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get deployment logs for a model version",
+        "summary": "Get deployment logs for a model API version",
         "tags": [
           "ModelManager"
         ]
@@ -50040,7 +54134,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Start a deployment of model version",
+        "summary": "Start a deployment of model API version",
         "tags": [
           "ModelManager"
         ]
@@ -50096,7 +54190,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Stop the deployment of model version",
+        "summary": "Stop the deployment of model API version",
         "tags": [
           "ModelManager"
         ]
@@ -50236,7 +54330,7 @@
     },
     "/workspace/events": {
       "get": {
-        "operationId": "listWorkspaceEvents",
+        "operationId": "notFound",
         "responses": {
           "200": {
             "content": {
@@ -50271,7 +54365,7 @@
     "/workspace/getGlobalSettings": {
       "get": {
         "operationId": "getGlobalSettings",
-        "parameters": [],
+        "parameters": null,
         "responses": {
           "200": {
             "content": {
@@ -51091,7 +55185,7 @@
     },
     "/workspace/project/{projectId}/workspace/{workspaceId}/getWritableProjectMounts": {
       "get": {
-        "operationId": "listWritableProjectMounts",
+        "operationId": "getWritableProjectMounts",
         "parameters": [
           {
             "description": "project id",
@@ -51347,7 +55441,7 @@
     },
     "/workspace/project/{projectId}/workspace/{workspaceId}/updateTitle": {
       "post": {
-        "operationId": "updateProjectWorkspaceTitle",
+        "operationId": "updateWorkspaceTitle",
         "parameters": [
           {
             "description": "Id of the project",
@@ -51787,7 +55881,7 @@
     },
     "/workspace/{executionId}/{clusterType}/hostAndPort": {
       "get": {
-        "operationId": "getWorkspaceComputeClusterHostAndPort",
+        "operationId": "getComputeClusterHostAndPort",
         "parameters": [
           {
             "description": "ID of the execution",
@@ -51883,7 +55977,7 @@
     },
     "/workspace/{projectId}/{clusterType}/defaultComputeClusterSettings": {
       "get": {
-        "operationId": "getWorkspaceDefaultComputeClusterSettings",
+        "operationId": "getDefaultComputeClusterSettings",
         "parameters": [
           {
             "description": "ID of the project",
@@ -51893,7 +55987,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "description": "Type of the cluster to get settings for",
@@ -51968,7 +56063,7 @@
               "default": 10000,
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -51979,7 +56074,7 @@
             "schema": {
               "default": 0,
               "format": "int32",
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -52059,7 +56154,7 @@
               "default": 10000,
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -52070,7 +56165,7 @@
             "schema": {
               "default": 0,
               "format": "int32",
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -52803,7 +56898,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterDetails": {
       "get": {
-        "operationId": "getWorkspaceComputeClusterDetails",
+        "operationId": "getComputeClusterDetails",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -52858,7 +56953,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterFileSync": {
       "post": {
-        "operationId": "syncWorkspaceFilesToComputeCluster",
+        "operationId": "syncFilesToComputeCluster",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -52913,7 +57008,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterFileSyncStatus": {
       "get": {
-        "operationId": "getWorkspaceComputeClusterFileSyncStatus",
+        "operationId": "getComputeClusterFileSyncStatus",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -52968,7 +57063,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterStatus": {
       "get": {
-        "operationId": "getWorkspaceComputeClusterStatus",
+        "operationId": "getComputeClusterStatus",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -53023,7 +57118,7 @@
     },
     "/workspace/{workspaceSessionId}/executionCheckpointStatuses": {
       "get": {
-        "operationId": "getExecutionCheckpointStatuses",
+        "operationId": "getExecutionCheckpointReport",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -53052,7 +57147,7 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "$ref": "#/components/schemas/domino.computegrid.ExecutionCheckpoint"
+                    "$ref": "#/components/schemas/domino.computegrid.MonitoredResourceExecutionCheckpoint"
                   },
                   "type": "array"
                 }
@@ -53073,7 +57168,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get each checkpoint name and their individual status for an execution",
+        "summary": "Get checkpoint in (name, status, and possibly detailed info about monitored resources associated with the checkpoint) for an execution",
         "tags": [
           "Workspace"
         ]
@@ -53139,7 +57234,7 @@
     },
     "/workspace/{workspaceSessionId}/usage": {
       "get": {
-        "operationId": "getWorkspaceSessionResourceUsage",
+        "operationId": "getResourceUsage",
         "parameters": [
           {
             "description": "projectId associated with the workspace",
@@ -53364,7 +57459,7 @@
     },
     "/workspaces/events": {
       "get": {
-        "operationId": "getWorkspaceEvents",
+        "operationId": "notFound",
         "responses": {
           "200": {
             "content": {
@@ -53498,7 +57593,7 @@
     },
     "/workspaces/project/{projectId}/environment/{environmentId}/availableTools": {
       "get": {
-        "operationId": "getAvailableToolsForEnvironmentInWorkspace",
+        "operationId": "getAvailableToolsForEnvironment",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -53968,7 +58063,7 @@
     },
     "/workspaces/{workspaceId}/allComments": {
       "get": {
-        "operationId": "getAllWorkspaceComments",
+        "operationId": "getAllComments",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -54128,7 +58223,7 @@
     },
     "/workspaces/{workspaceId}/comment/{threadId}": {
       "delete": {
-        "operationId": "archiveCommentFromThread",
+        "operationId": "archiveComment",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -54193,7 +58288,7 @@
     },
     "/workspaces/{workspaceId}/comments": {
       "get": {
-        "operationId": "getWorkspaceComments",
+        "operationId": "getComments",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -54238,7 +58333,7 @@
     },
     "/workspaces/{workspaceId}/executionCheckpointStatuses": {
       "get": {
-        "operationId": "getWorkspaceExecutionCheckpointStatuses",
+        "operationId": "getExecutionCheckpointStatuses",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -54416,7 +58511,7 @@
     },
     "/workspaces/{workspaceId}/logs": {
       "get": {
-        "operationId": "getWorkspaceLogs",
+        "operationId": "getLogs",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -54562,7 +58657,7 @@
     },
     "/workspaces/{workspaceId}/realTimeLogs": {
       "get": {
-        "operationId": "getWorkspaceRealTimeLogs",
+        "operationId": "getRealTimeLogs",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -54656,7 +58751,7 @@
     },
     "/workspaces/{workspaceId}/resourceStatuses": {
       "get": {
-        "operationId": "getWorkspaceRepositoryResourceStatus",
+        "operationId": "getWorkspaceRepositoryStatus",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -54711,7 +58806,7 @@
     },
     "/workspaces/{workspaceId}/resultFile/comments": {
       "get": {
-        "operationId": "getWorkspaceResultFileComments",
+        "operationId": "getResultFileComments",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -54774,7 +58869,7 @@
     },
     "/workspaces/{workspaceId}/results": {
       "get": {
-        "operationId": "getWorkspaceResults",
+        "operationId": "getResults",
         "parameters": [
           {
             "description": "ProjectId associated with the workspace",
@@ -54829,7 +58924,7 @@
     },
     "/workspaces/{workspaceId}/runtimeExecutionDetails": {
       "get": {
-        "operationId": "getWorkspaceRuntimeExecutionDetails",
+        "operationId": "getRuntimeExecutionDetails",
         "parameters": [
           {
             "description": "ProjectId for the workspace",
@@ -55199,7 +59294,7 @@
     },
     "/workspaces/{workspaceId}/usage": {
       "get": {
-        "operationId": "getWorkspaceResourceUsage",
+        "operationId": "getResourceUsage",
         "parameters": [
           {
             "description": "ProjectId associated with the workspace",

--- a/src/conf/domino-openapi.json
+++ b/src/conf/domino-openapi.json
@@ -30739,7 +30739,7 @@
             "description": "subPath to get files at",
             "in": "query",
             "name": "path",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             }

--- a/src/conf/domino-openapi.json
+++ b/src/conf/domino-openapi.json
@@ -31,6 +31,16 @@
         },
         "description": "An internal error prevented the server from performing this action"
       },
+      "ModelProductErrorResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
+            }
+          }
+        },
+        "description": ""
+      },
       "NotFound": {
         "content": {
           "application/json": {
@@ -105,19 +115,6 @@
           "Ray",
           "Dask",
           "MPI"
-        ],
-        "type": "string"
-      },
-      "DocumentType": {
-        "description": "List of searchable document types",
-        "enum": [
-          "project",
-          "file",
-          "run",
-          "model",
-          "environment",
-          "comment",
-          "dataset"
         ],
         "type": "string"
       },
@@ -393,7 +390,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -428,7 +425,7 @@
       "domino.activity.api.ActivityPagination": {
         "properties": {
           "latestTimeStamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "pageSize": {
@@ -2766,7 +2763,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -2806,7 +2803,7 @@
             "$ref": "#/components/schemas/domino.common.modelproduct.AppResourceUsage"
           },
           "started": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "status": {
@@ -2849,7 +2846,7 @@
             "type": "string"
           },
           "started": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "status": {
@@ -2931,7 +2928,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -3874,7 +3871,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -3913,8 +3910,9 @@
             "type": "string"
           },
           "extraInfo": {
+            "additionalProperties": true,
             "nullable": true,
-            "type": "play.api.libs.json.jsvalue"
+            "type": "object"
           },
           "fullName": {
             "type": "string"
@@ -4094,7 +4092,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -4723,7 +4721,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -5323,7 +5321,6 @@
           "UpdateDatasetRwV2",
           "PerformDatasetRwActionsAsAdminV2"
         ],
-        "properties": {},
         "type": "string"
       },
       "domino.datasetrw.api.DatasetRwProjectDetailsDto": {
@@ -5510,7 +5507,6 @@
           "Active",
           "Pending"
         ],
-        "properties": {},
         "type": "string"
       },
       "domino.datasetrw.api.DatasetRwSnapshotAdminSummaryDto": {
@@ -5688,40 +5684,6 @@
           "isReadWrite"
         ]
       },
-      "domino.datasetrw.api.DatasetRwStorageUsageDto": {
-        "properties": {
-          "isAtEmailThreshold": {
-            "type": "boolean"
-          },
-          "isAtWarningThreshold": {
-            "type": "boolean"
-          },
-          "limit": {
-            "format": "int64",
-            "type": "integer"
-          },
-          "quotaId": {
-            "pattern": "^[0-9a-f]{24}$",
-            "type": "string"
-          },
-          "targetId": {
-            "pattern": "^[0-9a-f]{24}$",
-            "type": "string"
-          },
-          "totalStorageUsed": {
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "quotaId",
-          "limit",
-          "totalStorageUsed",
-          "isAtWarningThreshold",
-          "isAtEmailThreshold"
-        ],
-        "type": "object"
-      },
       "domino.datasetrw.api.DatasetRwSummaryDto": {
         "properties": {
           "description": {
@@ -5792,7 +5754,7 @@
             "type": "string"
           },
           "lastTouched": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "uploadKey": {
@@ -8131,7 +8093,7 @@
       "domino.environments.api.RevisionSummary": {
         "properties": {
           "created": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "id": {
@@ -8604,7 +8566,8 @@
       "domino.featurestore.api.FeatureViewDto": {
         "properties": {
           "addedBy": {
-            "type": "collection.immutable.map[domino.common.dominoid,string]"
+            "additionalProperties": true,
+            "type": "object"
           },
           "author": {
             "nullable": true,
@@ -8891,7 +8854,7 @@
             "$ref": "#/components/schemas/domino.files.interface.CommentedBy"
           },
           "createdAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -10593,7 +10556,7 @@
             "$ref": "#/components/schemas/domino.jobs.interface.Commenter"
           },
           "created": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -11247,7 +11210,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -11460,7 +11423,7 @@
             "type": "integer"
           },
           "jobStartTime": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "jobStatus": {
@@ -11518,7 +11481,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -11658,7 +11621,7 @@
             "type": "string"
           },
           "lastModified": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "size": {
@@ -11677,17 +11640,17 @@
       "domino.jobs.interface.StageTime": {
         "properties": {
           "completedTime": {
-            "format": "epoch",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
           "runStartTime": {
-            "format": "epoch",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
           "submissionTime": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -11712,7 +11675,7 @@
       "domino.jobs.interface.TagApplication": {
         "properties": {
           "createdAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "createdBy": {
@@ -11868,7 +11831,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -11922,7 +11885,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -12424,7 +12387,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -12493,7 +12456,7 @@
             "type": "boolean"
           },
           "lastModified": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "name": {
@@ -12543,7 +12506,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -12694,7 +12657,7 @@
       "domino.modelmanager.api.ModelExport": {
         "properties": {
           "created": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "id": {
@@ -12798,7 +12761,7 @@
             "type": "string"
           },
           "created": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "exportId": {
@@ -13036,7 +12999,7 @@
             "type": "string"
           },
           "created": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "createdBy": {
@@ -13199,7 +13162,8 @@
             "type": "integer"
           },
           "modelAccess": {
-            "type": "collection.immutable.map[domino.common.dominoid,domino.server.modelmanager.application.modeldetailsaccess]"
+            "additionalProperties": true,
+            "type": "object"
           },
           "models": {
             "items": {
@@ -14121,7 +14085,7 @@
           "Critical",
           "Default"
         ],
-        "type": "String"
+        "type": "string"
       },
       "domino.notifications.Timeframe": {
         "properties": {
@@ -15860,7 +15824,7 @@
             "type": "array"
           },
           "updatedAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -15905,7 +15869,7 @@
             "type": "string"
           },
           "updatedAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -15922,7 +15886,7 @@
       "domino.projectManagement.api.FullSyncStatus": {
         "properties": {
           "lastSyncInitiatedAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "syncStatus": {
@@ -15976,7 +15940,7 @@
             "nullable": true
           },
           "created": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "dominoEntity": {
@@ -15987,7 +15951,7 @@
             "$ref": "#/components/schemas/domino.projectManagement.api.PmId"
           },
           "updatedAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -16136,7 +16100,7 @@
             "type": "string"
           },
           "updatedAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -16497,7 +16461,7 @@
             "type": "string"
           },
           "lastUpdatedAt": {
-            "format": "epoch",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
@@ -16550,7 +16514,7 @@
       "domino.projects.api.AssetPortfolioPaginationFilter": {
         "properties": {
           "pagination": {
-            "type": "domino.apiserverutils.pagination.paginationfilter"
+            "type": "string"
           },
           "searchQuery": {
             "nullable": true,
@@ -16616,7 +16580,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "usageCount": {
@@ -16652,7 +16616,7 @@
             "$ref": "#/components/schemas/domino.projects.api.ProjectStakeholder"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -16740,11 +16704,11 @@
             "$ref": "#/components/schemas/domino.projects.api.Commenter"
           },
           "created": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "updatedAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -16916,7 +16880,7 @@
             "$ref": "#/components/schemas/domino.projects.api.EntityLinkMetadata"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -17395,7 +17359,7 @@
             "type": "string"
           },
           "createdAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "createdBy": {
@@ -17420,17 +17384,17 @@
             "type": "boolean"
           },
           "lastDescriptionUpdatedAt": {
-            "format": "epoch",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
           "lastTitleUpdatedAt": {
-            "format": "epoch",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
           "lastUpdatedAt": {
-            "format": "epoch",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
@@ -17470,7 +17434,7 @@
             "type": "boolean"
           },
           "lastStageUpdatedAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "stage": {
@@ -17770,7 +17734,7 @@
             "type": "number"
           },
           "createdOn": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "duration": {
@@ -17778,7 +17742,7 @@
             "type": "integer"
           },
           "lastActivity": {
-            "format": "epoch",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
@@ -17839,7 +17803,7 @@
             "type": "boolean"
           },
           "pagination": {
-            "type": "domino.apiserverutils.pagination.paginationfilter"
+            "type": "string"
           },
           "searchQuery": {
             "nullable": true,
@@ -17932,7 +17896,7 @@
       "domino.projects.api.ProjectStage": {
         "properties": {
           "createdAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "createdBy": {
@@ -18708,7 +18672,7 @@
           "summary"
         ]
       },
-      "domino.projects.api.repositories.responses.GitApiResponseWrapper[domino.gitproviders.api.GetOwnersApiResponse]": {
+      "domino.projects.api.repositories.responses.GitApiResponseWrapper": {
         "properties": {
           "data": {
             "$ref": "#/components/schemas/domino.gitproviders.api.GetOwnersApiResponse"
@@ -18753,7 +18717,7 @@
       "domino.projects.api.repositories.responses.browse.CommitAuthorDTO": {
         "properties": {
           "date": {
-            "type": "date"
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -18857,7 +18821,7 @@
       "domino.projects.web.AddBlockedAtComment": {
         "properties": {
           "blockedAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "comment": {
@@ -19831,8 +19795,9 @@
             "type": "string"
           },
           "volumeSpecificationOverride": {
+            "additionalProperties": true,
             "nullable": true,
-            "type": "domino.run.api.volume.runondemandvolumespecification"
+            "type": "object"
           }
         },
         "required": [
@@ -19942,8 +19907,9 @@
             "type": "string"
           },
           "volumeSpecificationOverride": {
+            "additionalProperties": true,
             "nullable": true,
-            "type": "domino.run.api.volume.runondemandvolumespecification"
+            "type": "object"
           }
         },
         "required": [
@@ -20069,8 +20035,9 @@
             "type": "string"
           },
           "volumeSpecificationOverride": {
+            "additionalProperties": true,
             "nullable": true,
-            "type": "domino.run.api.volume.runondemandvolumespecification"
+            "type": "object"
           }
         },
         "required": [
@@ -20322,7 +20289,7 @@
       "domino.server.projectreleases.ProjectReleaseDto": {
         "properties": {
           "createdAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "createdBy": {
@@ -21076,7 +21043,7 @@
           },
           "diskUsage": {
             "nullable": true,
-            "type": "domino.run.api.rundiskusage"
+            "type": "string"
           },
           "environmentName": {
             "type": "string"
@@ -22390,7 +22357,7 @@
             "$ref": "#/components/schemas/domino.workspaces.api.Commenter"
           },
           "created": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -22757,7 +22724,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -22873,7 +22840,7 @@
             "type": "string"
           },
           "lastModified": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "size": {
@@ -22892,17 +22859,17 @@
       "domino.workspaces.api.StageTime": {
         "properties": {
           "completedTime": {
-            "format": "epoch",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
           "startTime": {
-            "format": "epoch",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
           "submissionTime": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -23160,7 +23127,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -23303,7 +23270,7 @@
       "domino.workspaces.api.WorkspaceTag": {
         "properties": {
           "createdAt": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "createdBy": {
@@ -23591,7 +23558,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "workspaceId": {
@@ -23629,7 +23596,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "epoch",
+            "format": "int64",
             "type": "integer"
           },
           "workspaceId": {
@@ -23891,7 +23858,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -23902,7 +23869,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -23963,7 +23930,7 @@
     },
     "/activity/metadata": {
       "get": {
-        "operationId": "notFound",
+        "operationId": "getActivityMetadata",
         "responses": {
           "200": {
             "content": {
@@ -24014,7 +23981,7 @@
             "required": true,
             "schema": {
               "format": "int32",
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -24033,7 +24000,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -24044,7 +24011,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           }
         ],
@@ -24611,6 +24578,7 @@
     "/admin/notifications/admin": {
       "post": {
         "operationId": "createNotificationSuperUser",
+        "responses": {},
         "tags": [
           "adminnotifications"
         ]
@@ -24829,8 +24797,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -24875,8 +24842,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -24921,8 +24887,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -25097,9 +25062,10 @@
     "/controlCenter/utilization/kubecostDeployed": {
       "get": {
         "operationId": "getKubecostLiveness",
+        "responses": {},
         "summary": "this endpoint will be temporarily used to discover if Kubecost is installed and will be removed if we retire the current cost& compute page",
         "tags": [
-          "controlcenter"
+          "Control Center"
         ]
       }
     },
@@ -26932,7 +26898,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "#/components/schemas/domino.dataplane.DataPlane"
+                  "$ref": "#/components/schemas/domino.dataplane.DataPlane"
                 }
               }
             },
@@ -27024,7 +26990,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "#/components/schemas/domino.dataplane.DataPlane"
+                  "$ref": "#/components/schemas/domino.dataplane.DataPlane"
                 }
               }
             },
@@ -27069,7 +27035,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "#/components/schemas/domino.dataplane.DataPlane"
+                  "$ref": "#/components/schemas/domino.dataplane.DataPlane"
                 }
               }
             },
@@ -27097,7 +27063,7 @@
     "/dataplanes/targetVersion": {
       "get": {
         "operationId": "getTargetDataPlaneVersion",
-        "parameters": null,
+        "parameters": [],
         "responses": {
           "200": {
             "content": {
@@ -27167,7 +27133,7 @@
     },
     "/datasetUi/collections": {
       "post": {
-        "operationId": "createDataset",
+        "operationId": "createDatasetCollection",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -27325,7 +27291,7 @@
     },
     "/datasetUi/collections/{datasetId}": {
       "post": {
-        "operationId": "updateDataset",
+        "operationId": "updateDatasetUi",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -27475,7 +27441,7 @@
     },
     "/datasetUi/collections/{datasetId}/snapshot/file": {
       "post": {
-        "operationId": "uploadSnapshotFile",
+        "operationId": "uploadSnapshotFileUi",
         "parameters": [
           {
             "in": "path",
@@ -27628,7 +27594,13 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/components/schemas/domino.dataset.api.DatasetSnapshotDto",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.dataset.api.DatasetSnapshotDto"
+                }
+              }
+            },
             "description": "the new snapshot"
           },
           "400": {
@@ -27832,7 +27804,7 @@
     },
     "/datasetUi/collections/{datasetId}/snapshots": {
       "get": {
-        "operationId": "getSnapshots",
+        "operationId": "getSnapshotsUi",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -28386,7 +28358,7 @@
     },
     "/datasetUi/project/{projectId}/canAddDataset": {
       "get": {
-        "operationId": "canAddDataset",
+        "operationId": "canAddDatasetUi",
         "parameters": [
           {
             "description": "Project identifier",
@@ -28816,7 +28788,7 @@
     },
     "/datasetUi/{snapshotId}": {
       "get": {
-        "operationId": "getSnapshot",
+        "operationId": "getSnapshotUi",
         "parameters": [
           {
             "description": "Id of the snapshot",
@@ -29062,7 +29034,6 @@
           "200": {
             "content": {
               "application/json": {
-                "required": false,
                 "schema": {
                   "type": "number"
                 }
@@ -29809,7 +29780,7 @@
     },
     "/datasetrw/dataset/{datasetId}/tag": {
       "post": {
-        "operationId": "addTag",
+        "operationId": "addDatasetTag",
         "parameters": [
           {
             "description": "Dataset ID",
@@ -29865,7 +29836,7 @@
     },
     "/datasetrw/dataset/{datasetId}/tag/{tagName}": {
       "delete": {
-        "operationId": "removeTag",
+        "operationId": "removeDatasetTag",
         "parameters": [
           {
             "description": "Dataset ID",
@@ -30136,7 +30107,7 @@
     },
     "/datasetrw/datasets/limit/{projectId}": {
       "post": {
-        "operationId": "setLimitOverride",
+        "operationId": "setDatasetLimitOverride",
         "parameters": [
           {
             "description": "Id of the project",
@@ -30487,7 +30458,7 @@
     },
     "/datasetrw/datasets/{datasetId}/snapshot/file/cancel/{uploadKey}": {
       "get": {
-        "operationId": "cancelSnapshotUpload",
+        "operationId": "cancelDatasetSnapshotUpload",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -30534,7 +30505,7 @@
     },
     "/datasetrw/datasets/{datasetId}/snapshot/file/end/{uploadKey}": {
       "get": {
-        "operationId": "endSnapshotUpload",
+        "operationId": "endDatasetSnapshotUpload",
         "parameters": [
           {
             "in": "path",
@@ -30586,7 +30557,7 @@
     },
     "/datasetrw/datasets/{datasetId}/snapshot/file/start": {
       "post": {
-        "operationId": "startSnapshotUpload",
+        "operationId": "startDatasetSnapshotUpload",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -30725,7 +30696,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "string"
                 }
               }
             },
@@ -30824,7 +30795,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "string"
                 }
               }
             },
@@ -30887,7 +30858,7 @@
     },
     "/datasetrw/marked-snapshots": {
       "delete": {
-        "operationId": "deleteMarkedSnapshots",
+        "operationId": "deleteDatasetMarkedSnapshots",
         "responses": {
           "200": {
             "content": {
@@ -31377,7 +31348,7 @@
     },
     "/datasetrw/snapshot/upload/{uploadKey}": {
       "get": {
-        "operationId": "getSnapshotUploadSession",
+        "operationId": "getDatasetSnapshotUploadSession",
         "parameters": [
           {
             "in": "path",
@@ -31420,7 +31391,7 @@
     },
     "/datasetrw/snapshot/{snapshotId}": {
       "delete": {
-        "operationId": "deleteSnapshot",
+        "operationId": "deleteDatasetSnapshot",
         "parameters": [
           {
             "description": "Snapshot ID",
@@ -31506,7 +31477,7 @@
         ]
       },
       "put": {
-        "operationId": "updateSnapshotStatus",
+        "operationId": "updateDatasetSnapshotStatus",
         "parameters": [
           {
             "description": "Id of the dataset snapshot to be updated",
@@ -32109,7 +32080,8 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "type": "binary"
+                  "format": "binary",
+                  "type": "string"
                 }
               }
             },
@@ -32287,7 +32259,7 @@
     },
     "/datasetrw/snapshots/summary/{datasetId}": {
       "get": {
-        "operationId": "getSnapshotSummaries",
+        "operationId": "getDatasetSnapshotSummaries",
         "parameters": [
           {
             "description": "Dataset ID",
@@ -32403,7 +32375,6 @@
           "200": {
             "content": {
               "application/json": {
-                "required": true,
                 "schema": {
                   "items": {
                     "$ref": "#/components/schemas/domino.datasetrw.api.DatasetStorageUsageDto"
@@ -32451,7 +32422,6 @@
           "200": {
             "content": {
               "application/json": {
-                "required": false,
                 "schema": {
                   "$ref": "#/components/schemas/domino.datasetrw.api.DatasetStorageUsageDto"
                 }
@@ -32620,7 +32590,7 @@
         ]
       },
       "post": {
-        "operationId": "create",
+        "operationId": "createDataSource",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -32734,7 +32704,8 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "type": "binary"
+                  "format": "binary",
+                  "type": "string"
                 }
               }
             },
@@ -32792,7 +32763,8 @@
             "content": {
               "application/jsonl": {
                 "schema": {
-                  "type": "binary"
+                  "format": "binary",
+                  "type": "string"
                 }
               }
             },
@@ -32865,7 +32837,7 @@
     },
     "/datasource/auths/all": {
       "get": {
-        "operationId": "getAuthConfigs",
+        "operationId": "getDataSourceAuthConfigs",
         "parameters": [],
         "responses": {
           "200": {
@@ -33077,7 +33049,7 @@
     },
     "/datasource/full": {
       "get": {
-        "operationId": "getFullCredentials",
+        "operationId": "getDataSourceFullCredentials",
         "parameters": [
           {
             "description": "registered data source id",
@@ -34478,7 +34450,7 @@
     },
     "/datasource/{dataSourceId}/projects/{projectId}": {
       "delete": {
-        "operationId": "removeProject",
+        "operationId": "removeProjectFromDataSource",
         "parameters": [
           {
             "description": "Data source Id",
@@ -34531,7 +34503,7 @@
         ]
       },
       "post": {
-        "operationId": "addProject",
+        "operationId": "addProjectToDataSource",
         "parameters": [
           {
             "description": "Data source Id",
@@ -34694,7 +34666,7 @@
     },
     "/datasource/{dataSourceId}/users": {
       "delete": {
-        "operationId": "removeUsers",
+        "operationId": "removeUsersFromDataSource",
         "parameters": [
           {
             "description": "Data source Id",
@@ -34750,7 +34722,7 @@
         ]
       },
       "post": {
-        "operationId": "addUsers",
+        "operationId": "addUsersToDataSource",
         "parameters": [
           {
             "description": "Data source Id",
@@ -34806,7 +34778,7 @@
         ]
       },
       "put": {
-        "operationId": "updateUsers",
+        "operationId": "updateUsersForDataSource",
         "parameters": [
           {
             "description": "data source id",
@@ -35094,6 +35066,17 @@
         "operationId": "setDefaultEnvironment",
         "parameters": [],
         "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.environments.api.SetDeployDefaultEnvRequest"
+              }
+            }
+          },
+          "description": "The ID of the environment to set as the deployment default",
+          "required": true
+        },
+        "responses": {
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
@@ -35105,16 +35088,7 @@
           },
           "500": {
             "$ref": "#/components/responses/InternalError"
-          },
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/domino.environments.api.SetDeployDefaultEnvRequest"
-              }
-            }
-          },
-          "description": "The ID of the environment to set as the deployment default",
-          "required": true
+          }
         },
         "summary": "Set default environment",
         "tags": [
@@ -35717,7 +35691,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -35728,7 +35702,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -35739,7 +35713,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -35851,7 +35825,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -35862,7 +35836,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -35873,7 +35847,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -37764,7 +37738,7 @@
     },
     "/frontend/snippets": {
       "get": {
-        "operationId": "list",
+        "operationId": "listFrontendSnippets",
         "parameters": [],
         "responses": {
           "200": {
@@ -37795,7 +37769,7 @@
     },
     "/gateway/projects": {
       "get": {
-        "operationId": "list",
+        "operationId": "listProjects",
         "parameters": [
           {
             "description": "The relationship between the current user and the projects to be returned",
@@ -38037,7 +38011,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           }
         ],
@@ -38105,7 +38079,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -38218,7 +38192,7 @@
                 "bitbucket",
                 "bitbucketServer"
               ],
-              "type": "#/components/schemas/domino.repoman.domain.GitProviderName"
+              "type": "string"
             }
           },
           {
@@ -38288,7 +38262,7 @@
                 "bitbucket",
                 "bitbucketServer"
               ],
-              "type": "#/components/schemas/domino.repoman.domain.GitProviderName"
+              "type": "string"
             }
           },
           {
@@ -38298,7 +38272,7 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "#/components/schemas/domino.common.DominoId"
+              "type": "string"
             }
           }
         ],
@@ -38307,7 +38281,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/domino.projects.api.repositories.responses.GitApiResponseWrapper[domino.gitproviders.api.GetOwnersApiResponse]"
+                  "$ref": "#/components/schemas/domino.projects.api.repositories.responses.GitApiResponseWrapper"
                 }
               }
             },
@@ -38349,7 +38323,7 @@
                 "bitbucket",
                 "bitbucketServer"
               ],
-              "type": "#/components/schemas/domino.repoman.domain.GitProviderName"
+              "type": "string"
             }
           },
           {
@@ -38359,7 +38333,7 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "#/components/schemas/domino.common.DominoId"
+              "type": "string"
             }
           },
           {
@@ -38615,7 +38589,7 @@
             "required": false,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "domino.common.DominoId"
+              "type": "string"
             }
           }
         ],
@@ -38670,7 +38644,7 @@
             "required": false,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "domino.common.DominoId"
+              "type": "string"
             }
           }
         ],
@@ -38837,8 +38811,7 @@
             "required": true,
             "schema": {
               "type": "string"
-            },
-            "type": "string"
+            }
           },
           {
             "description": "Id of the project",
@@ -38848,8 +38821,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           },
           {
             "description": "Command parameters that needs to be passed to the job",
@@ -38858,8 +38830,7 @@
             "required": true,
             "schema": {
               "type": "string"
-            },
-            "type": "string"
+            }
           }
         ],
         "responses": {
@@ -38933,7 +38904,7 @@
     },
     "/jobs/events": {
       "get": {
-        "operationId": "notFound",
+        "operationId": "getJobEvents",
         "responses": {
           "200": {
             "content": {
@@ -38967,7 +38938,7 @@
     },
     "/jobs/getStatus/values": {
       "get": {
-        "operationId": "getStatus",
+        "operationId": "getJobStatusValues",
         "parameters": [],
         "responses": {
           "200": {
@@ -39016,10 +38987,14 @@
         ],
         "responses": {
           "200": {
-            "description": "success",
-            "schema": {
-              "$ref": "#/components/schemas/domino.jobs.interface.ArtifactsInfoDto"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.jobs.interface.ArtifactsInfoDto"
+                }
+              }
+            },
+            "description": "success"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -39114,10 +39089,14 @@
         ],
         "responses": {
           "200": {
-            "description": "success",
-            "schema": {
-              "$ref": "#/components/schemas/domino.jobs.interface.CodeInfoDto"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.jobs.interface.CodeInfoDto"
+                }
+              }
+            },
+            "description": "success"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -39646,8 +39625,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -39692,8 +39670,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -39728,7 +39705,7 @@
     },
     "/jobs/{jobId}/computeClusterFileSyncStatus": {
       "get": {
-        "operationId": "getComputeClusterFileSyncStatus",
+        "operationId": "getJobComputeClusterFileSyncStatus",
         "parameters": [
           {
             "description": "ID of the job",
@@ -39738,8 +39715,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -39774,7 +39750,7 @@
     },
     "/jobs/{jobId}/computeClusterStatus": {
       "get": {
-        "operationId": "getComputeClusterStatus",
+        "operationId": "getJobComputeClusterStatus",
         "parameters": [
           {
             "description": "ID of the job",
@@ -39784,8 +39760,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -39893,7 +39868,7 @@
     },
     "/jobs/{jobId}/linkJobToGoal": {
       "post": {
-        "operationId": "linkJobToGoal",
+        "operationId": "linkSingleJobToGoal",
         "parameters": [
           {
             "in": "path",
@@ -40674,8 +40649,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           },
           {
             "description": "Type of the cluster to get settings for",
@@ -41167,7 +41141,7 @@
     },
     "/modelManager/buildModelImage": {
       "post": {
-        "operationId": "buildModelImage",
+        "operationId": "buildManagerModelImage",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -41182,10 +41156,14 @@
         },
         "responses": {
           "200": {
-            "description": "Request accepted, building of model API image continues offline",
-            "schema": {
-              "$ref": "#/components/schemas/domino.modelmanager.api.ModelBuild"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.modelmanager.api.ModelBuild"
+                }
+              }
+            },
+            "description": "Request accepted, building of model API image continues offline"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -41223,10 +41201,14 @@
         },
         "responses": {
           "200": {
-            "description": "Request accepted, exporting of image continues offline",
-            "schema": {
-              "$ref": "#/components/schemas/domino.modelmanager.web.ExportVersionStatusWithoutModelResponse"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.modelmanager.web.ExportVersionStatusWithoutModelResponse"
+                }
+              }
+            },
+            "description": "Request accepted, exporting of image continues offline"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -41283,10 +41265,14 @@
         },
         "responses": {
           "200": {
-            "description": "Request accepted, exporting of model API image continues offline",
-            "schema": {
-              "$ref": "#/components/schemas/domino.modelmanager.api.ModelExportVersionStatus"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.modelmanager.api.ModelExportVersionStatus"
+                }
+              }
+            },
+            "description": "Request accepted, exporting of model API image continues offline"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -41349,7 +41335,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           }
         ],
@@ -41428,7 +41414,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           }
         ],
@@ -41497,7 +41483,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           }
         ],
@@ -41633,7 +41619,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -41812,7 +41798,7 @@
               "format": "int32",
               "minimum": 0,
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -41824,7 +41810,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -41905,7 +41891,7 @@
               "format": "int32",
               "minimum": 0,
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -41917,7 +41903,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -42113,11 +42099,15 @@
         "responses": {
           "200": {
             "description": "success",
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/domino.modelmanager.api.responses.ModelPermissionForMonitoringApiResponse"
-              },
-              "type": "array"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.modelmanager.api.responses.ModelPermissionForMonitoringApiResponse"
+                  },
+                  "type": "array"
+                }
+              }
             }
           },
           "400": {
@@ -42198,7 +42188,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -42210,7 +42200,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -42270,16 +42260,20 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "success",
-            "schema": {
-              "$ref": "#/components/schemas/domino.modelmanager.api.ModelsForUIApiResponse"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.modelmanager.api.ModelsForUIApiResponse"
+                }
+              }
+            },
+            "description": "success"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -42317,10 +42311,14 @@
         ],
         "responses": {
           "200": {
-            "description": "success",
-            "schema": {
-              "$ref": "#/components/schemas/domino.modelmanager.api.responses.ModelPermissionsForUIApiResponse"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.modelmanager.api.responses.ModelPermissionsForUIApiResponse"
+                }
+              }
+            },
+            "description": "success"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -43262,10 +43260,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
+            "$ref": "#/components/responses/ModelProductErrorResponse"
           },
           "500": {
-            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
+            "$ref": "#/components/responses/ModelProductErrorResponse"
           }
         },
         "summary": "list top model product views for a given time range",
@@ -43571,7 +43569,7 @@
     },
     "/modelProducts/{modelProductId}/start": {
       "post": {
-        "operationId": "start",
+        "operationId": "startModelProduct",
         "parameters": [
           {
             "in": "path",
@@ -43625,7 +43623,7 @@
     },
     "/modelProducts/{modelProductId}/stop": {
       "post": {
-        "operationId": "stop",
+        "operationId": "stopModelProduct",
         "parameters": [
           {
             "description": "Domino id of the model product (app)",
@@ -43732,10 +43730,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
+            "$ref": "#/components/responses/ModelProductErrorResponse"
           },
           "500": {
-            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
+            "$ref": "#/components/responses/ModelProductErrorResponse"
           }
         },
         "summary": "get count of views on one model product for a given time range",
@@ -43788,10 +43786,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
+            "$ref": "#/components/responses/ModelProductErrorResponse"
           },
           "500": {
-            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
+            "$ref": "#/components/responses/ModelProductErrorResponse"
           }
         },
         "summary": "get count of views on one model product for a given time range",
@@ -43870,13 +43868,17 @@
         ],
         "responses": {
           "200": {
-            "description": "success",
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/domino.common.modelproduct.AppVersionOverview"
-              },
-              "type": "array"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.common.modelproduct.AppVersionOverview"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -43977,10 +43979,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
+            "$ref": "#/components/responses/ModelProductErrorResponse"
           },
           "500": {
-            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
+            "$ref": "#/components/responses/ModelProductErrorResponse"
           }
         },
         "summary": "record a view on a model product",
@@ -44263,6 +44265,7 @@
             }
           }
         ],
+        "responses": {},
         "tags": [
           "photonRawData"
         ]
@@ -44660,7 +44663,7 @@
     },
     "/projectManagement/goal/{goalId}": {
       "delete": {
-        "operationId": "deleteProjectGoal",
+        "operationId": "deleteManageProjectGoal",
         "parameters": [
           {
             "in": "path",
@@ -44722,8 +44725,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -44771,8 +44773,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           },
           {
             "description": "Domino id of user being assigned to the goal",
@@ -44782,8 +44783,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -44821,7 +44821,7 @@
     },
     "/projectManagement/goal/{goalId}/comment": {
       "post": {
-        "operationId": "addCommentOnGoal",
+        "operationId": "addManageCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -44886,7 +44886,7 @@
     },
     "/projectManagement/goal/{goalId}/comment/list": {
       "get": {
-        "operationId": "getCommentsOnGoal",
+        "operationId": "getManageCommentsOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -44950,8 +44950,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -45002,8 +45001,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           },
           {
             "description": "Domino id of the project stage",
@@ -45013,8 +45011,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           },
           {
             "in": "cookie",
@@ -45059,7 +45056,7 @@
     },
     "/projectManagement/goal/{goalId}/updateDescription": {
       "post": {
-        "operationId": "updateProjectGoalDescription",
+        "operationId": "updateManageProjectGoalDescription",
         "parameters": [
           {
             "in": "path",
@@ -45124,7 +45121,7 @@
     },
     "/projectManagement/goal/{goalId}/updateTitle": {
       "post": {
-        "operationId": "updateProjectGoalTitle",
+        "operationId": "updateManageProjectGoalTitle",
         "parameters": [
           {
             "in": "path",
@@ -45189,7 +45186,7 @@
     },
     "/projectManagement/goalComment/{threadId}/{commentId}": {
       "delete": {
-        "operationId": "archiveCommentOnGoal",
+        "operationId": "archiveManageCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -45250,7 +45247,7 @@
         ]
       },
       "put": {
-        "operationId": "updateCommentOnGoal",
+        "operationId": "updateManageCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -45324,7 +45321,7 @@
     },
     "/projectManagement/goalComment/{threadId}/{commentId}/canUpdate": {
       "get": {
-        "operationId": "canUpdateCommentOnGoal",
+        "operationId": "canUpdateManageCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -45647,7 +45644,7 @@
     },
     "/projectManagement/linkFileToGoal": {
       "post": {
-        "operationId": "linkFileToGoal",
+        "operationId": "linkManageFileToGoalForProject",
         "parameters": [
           {
             "in": "cookie",
@@ -45759,7 +45756,7 @@
     },
     "/projectManagement/project/{projectId}/comment": {
       "post": {
-        "operationId": "addCommentOnProject",
+        "operationId": "addManageCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -45824,7 +45821,7 @@
     },
     "/projectManagement/project/{projectId}/comment/list": {
       "get": {
-        "operationId": "getCommentsOnProject",
+        "operationId": "getManageCommentsOnProject",
         "parameters": [
           {
             "in": "path",
@@ -45888,8 +45885,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -45930,7 +45926,7 @@
     },
     "/projectManagement/projectComment/{threadId}/{commentId}": {
       "delete": {
-        "operationId": "archiveCommentOnProject",
+        "operationId": "archiveManageCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -45991,7 +45987,7 @@
         ]
       },
       "put": {
-        "operationId": "updateCommentOnProject",
+        "operationId": "updateManageCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -46065,7 +46061,7 @@
     },
     "/projectManagement/projectComment/{threadId}/{commentId}/canUpdate": {
       "get": {
-        "operationId": "canUpdateCommentOnProject",
+        "operationId": "canUpdateManageCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -46164,7 +46160,7 @@
     },
     "/projectManagement/unlinkFileFromGoal": {
       "post": {
-        "operationId": "unlinkFileFromGoal",
+        "operationId": "unlinkManageProjectFileFromGoal",
         "parameters": [
           {
             "in": "cookie",
@@ -46322,7 +46318,7 @@
     },
     "/projectManagement/{jobId}/unlinkJobFromGoal": {
       "post": {
-        "operationId": "unlinkJobFromGoal",
+        "operationId": "unlinkManageJobFromGoal",
         "parameters": [
           {
             "in": "path",
@@ -46442,7 +46438,7 @@
     },
     "/projectManagement/{projectId}/createGoal": {
       "post": {
-        "operationId": "createProjectGoal",
+        "operationId": "createManageProjectGoal",
         "parameters": [
           {
             "in": "path",
@@ -46572,8 +46568,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -46621,8 +46616,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -46673,8 +46667,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -46712,7 +46705,7 @@
     },
     "/projectManagement/{projectId}/goals": {
       "get": {
-        "operationId": "getProjectGoals",
+        "operationId": "getManageProjectGoals",
         "parameters": [
           {
             "in": "path",
@@ -46854,8 +46847,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           },
           {
             "in": "query",
@@ -46906,66 +46898,6 @@
         ]
       }
     },
-    "/projectManagement/{projectId}/projectGoalStages": {
-      "get": {
-        "operationId": "getProjectGoalStages",
-        "parameters": [
-          {
-            "description": "Domino id of the project to get goal stages from",
-            "in": "path",
-            "name": "projectId",
-            "required": true,
-            "schema": {
-              "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            },
-            "type": "domino.common.DominoId"
-          },
-          {
-            "description": "Include archived stages in the results",
-            "in": "query",
-            "name": "includeArchived",
-            "required": false,
-            "schema": {
-              "nullable": true,
-              "type": "boolean"
-            },
-            "type": "Boolean"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.projects.api.ProjectStage"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "success"
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "500": {
-            "$ref": "#/components/responses/InternalError"
-          }
-        },
-        "summary": "Get all project goal stages on a project.",
-        "tags": [
-          "ProjectManagement"
-        ]
-      }
-    },
     "/projectManagement/{projectId}/unlinkAndResetProject": {
       "post": {
         "operationId": "unlinkAndResetProject",
@@ -46978,8 +46910,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -47020,8 +46951,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           },
           {
             "in": "query",
@@ -47129,7 +47059,7 @@
     },
     "/projectManagement/{workspaceId}/linkWorkspaceToGoal": {
       "post": {
-        "operationId": "linkWorkspaceToGoal",
+        "operationId": "linkManageWorkspaceToGoal",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -47139,8 +47069,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           },
           {
             "in": "cookie",
@@ -47196,7 +47125,7 @@
     },
     "/projectManagement/{workspaceId}/unlinkWorkspaceFromGoal": {
       "post": {
-        "operationId": "unlinkWorkspaceFromGoal",
+        "operationId": "unlinkManageWorkspaceFromGoal",
         "parameters": [
           {
             "in": "path",
@@ -47311,8 +47240,7 @@
             "required": true,
             "schema": {
               "type": "string"
-            },
-            "type": "String"
+            }
           },
           {
             "description": "Id of the project",
@@ -47322,8 +47250,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           }
         ],
         "responses": {
@@ -47390,7 +47317,7 @@
     },
     "/projects/dontCall": {
       "get": {
-        "operationId": "notFound",
+        "operationId": "getProjectStatuses",
         "responses": {
           "200": {
             "content": {
@@ -48006,7 +47933,7 @@
     },
     "/projects/portfolio/moveProjectToStage": {
       "post": {
-        "operationId": "moveProjectToStage",
+        "operationId": "movePortfolioProjectToStage",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -48829,7 +48756,7 @@
     },
     "/projects/{projectId}/comments": {
       "get": {
-        "operationId": "getCommentsOnProject",
+        "operationId": ";ostCommentsOnProject",
         "parameters": [
           {
             "description": "Domino id of the project",
@@ -49931,7 +49858,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -49944,7 +49871,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -50775,7 +50702,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/domino.common.DominoId"
+                  "type": "string"
                 }
               }
             },
@@ -50928,7 +50855,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/domino.common.DominoId"
+                  "type": "string"
                 }
               }
             },
@@ -51826,7 +51753,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "string"
                 }
               }
             },
@@ -51899,7 +51826,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "string"
                 }
               }
             },
@@ -51972,7 +51899,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "string"
                 }
               }
             },
@@ -52036,7 +51963,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "string"
                 }
               }
             },
@@ -52220,7 +52147,6 @@
           "200": {
             "content": {
               "application/json": {
-                "required": false,
                 "schema": {
                   "$ref": "#/components/schemas/domino.quota.api.QuotaDto"
                 }
@@ -52554,7 +52480,7 @@
     },
     "/tags": {
       "get": {
-        "operationId": "list",
+        "operationId": "listTags",
         "parameters": [
           {
             "description": "Optional filter for a tag by name",
@@ -52900,10 +52826,14 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "success",
-            "schema": {
-              "type": "boolean"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "description": "success"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -52936,15 +52866,21 @@
             "in": "header",
             "name": "X-Domino-Api-Key",
             "required": false,
-            "type": "string"
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "success",
-            "schema": {
-              "$ref": "#/components/schemas/domino.common.user.LiteUserResponseDTO"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.common.user.LiteUserResponseDTO"
+                }
+              }
+            },
+            "description": "success"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -53009,7 +52945,6 @@
             }
           },
           {
-            "default": "created",
             "description": "Specify sort criteria (optional, incompatible with defaultSort=true)",
             "in": "query",
             "name": "sort",
@@ -53028,7 +52963,6 @@
             }
           },
           {
-            "default": "desc",
             "description": "Specify sort direction (optional, incompatible with defaultSort=true)",
             "in": "query",
             "name": "dir",
@@ -53043,7 +52977,6 @@
             }
           },
           {
-            "default": false,
             "description": "If true, use the frontend's default sorting and return 400 if either 'sort' or 'dir' are set.",
             "in": "query",
             "name": "defaultSort",
@@ -53487,13 +53420,17 @@
         },
         "responses": {
           "202": {
-            "description": "Request accepted, building of model API image continues offline",
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/domino.modelmanager.web.BuildModelImageApiResponse"
-              },
-              "type": "array"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.modelmanager.web.BuildModelImageApiResponse"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Request accepted, building of model API image continues offline"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -53563,7 +53500,7 @@
     },
     "/v4/models/{exportId}/getExportLogs": {
       "get": {
-        "operationId": "getExportVersionLogs",
+        "operationId": "getModelExportVersionLogs",
         "parameters": [
           {
             "in": "path",
@@ -53644,13 +53581,17 @@
         },
         "responses": {
           "202": {
-            "description": "Request accepted, exporting of model API image continues offline",
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-              },
-              "type": "array"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Request accepted, exporting of model API image continues offline"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -53707,13 +53648,17 @@
         },
         "responses": {
           "202": {
-            "description": "Request accepted, exporting of model API image continues offline",
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-              },
-              "type": "array"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Request accepted, exporting of model API image continues offline"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -53736,7 +53681,7 @@
     },
     "/v4/models/{modelId}/{modelVersionId}/exportImageForSnowflake": {
       "post": {
-        "operationId": "exportImageForSnowflake",
+        "operationId": "exportModelImageForSnowflake",
         "parameters": [
           {
             "in": "path",
@@ -53770,13 +53715,17 @@
         },
         "responses": {
           "202": {
-            "description": "Request accepted, exporting of model API image continues offline",
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-              },
-              "type": "array"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Request accepted, exporting of model API image continues offline"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -53833,13 +53782,17 @@
         },
         "responses": {
           "202": {
-            "description": "Request accepted, exporting of model API image continues offline",
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-              },
-              "type": "array"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Request accepted, exporting of model API image continues offline"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -53862,7 +53815,7 @@
     },
     "/v4/models/{modelId}/{modelVersionId}/getBuildLogs": {
       "get": {
-        "operationId": "getBuildLogs",
+        "operationId": "getModelBuildLogs",
         "parameters": [
           {
             "in": "path",
@@ -54330,7 +54283,7 @@
     },
     "/workspace/events": {
       "get": {
-        "operationId": "notFound",
+        "operationId": "listWorkspaceEvents",
         "responses": {
           "200": {
             "content": {
@@ -54365,7 +54318,7 @@
     "/workspace/getGlobalSettings": {
       "get": {
         "operationId": "getGlobalSettings",
-        "parameters": null,
+        "parameters": [],
         "responses": {
           "200": {
             "content": {
@@ -55185,7 +55138,7 @@
     },
     "/workspace/project/{projectId}/workspace/{workspaceId}/getWritableProjectMounts": {
       "get": {
-        "operationId": "getWritableProjectMounts",
+        "operationId": "listWritableProjectMounts",
         "parameters": [
           {
             "description": "project id",
@@ -55441,7 +55394,7 @@
     },
     "/workspace/project/{projectId}/workspace/{workspaceId}/updateTitle": {
       "post": {
-        "operationId": "updateWorkspaceTitle",
+        "operationId": "updateProjectWorkspaceTitle",
         "parameters": [
           {
             "description": "Id of the project",
@@ -55881,7 +55834,7 @@
     },
     "/workspace/{executionId}/{clusterType}/hostAndPort": {
       "get": {
-        "operationId": "getComputeClusterHostAndPort",
+        "operationId": "getWorkspaceComputeClusterHostAndPort",
         "parameters": [
           {
             "description": "ID of the execution",
@@ -55977,7 +55930,7 @@
     },
     "/workspace/{projectId}/{clusterType}/defaultComputeClusterSettings": {
       "get": {
-        "operationId": "getDefaultComputeClusterSettings",
+        "operationId": "getWorkspaceDefaultComputeClusterSettings",
         "parameters": [
           {
             "description": "ID of the project",
@@ -55987,8 +55940,7 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            },
-            "type": "domino.common.DominoId"
+            }
           },
           {
             "description": "Type of the cluster to get settings for",
@@ -56063,7 +56015,7 @@
               "default": 10000,
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -56074,7 +56026,7 @@
             "schema": {
               "default": 0,
               "format": "int32",
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -56154,7 +56106,7 @@
               "default": 10000,
               "format": "int32",
               "nullable": true,
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -56165,7 +56117,7 @@
             "schema": {
               "default": 0,
               "format": "int32",
-              "type": "number"
+              "type": "integer"
             }
           },
           {
@@ -56898,7 +56850,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterDetails": {
       "get": {
-        "operationId": "getComputeClusterDetails",
+        "operationId": "getWorkspaceComputeClusterDetails",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -56953,7 +56905,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterFileSync": {
       "post": {
-        "operationId": "syncFilesToComputeCluster",
+        "operationId": "syncWorkspaceFilesToComputeCluster",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -57008,7 +56960,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterFileSyncStatus": {
       "get": {
-        "operationId": "getComputeClusterFileSyncStatus",
+        "operationId": "getWorkspaceComputeClusterFileSyncStatus",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -57063,7 +57015,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterStatus": {
       "get": {
-        "operationId": "getComputeClusterStatus",
+        "operationId": "getWorkspaceComputeClusterStatus",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -57118,7 +57070,7 @@
     },
     "/workspace/{workspaceSessionId}/executionCheckpointStatuses": {
       "get": {
-        "operationId": "getExecutionCheckpointReport",
+        "operationId": "getExecutionCheckpointStatuses",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -57234,7 +57186,7 @@
     },
     "/workspace/{workspaceSessionId}/usage": {
       "get": {
-        "operationId": "getResourceUsage",
+        "operationId": "getWorkspaceSessionResourceUsage",
         "parameters": [
           {
             "description": "projectId associated with the workspace",
@@ -57459,7 +57411,7 @@
     },
     "/workspaces/events": {
       "get": {
-        "operationId": "notFound",
+        "operationId": "getWorkspaceEvents",
         "responses": {
           "200": {
             "content": {
@@ -57593,7 +57545,7 @@
     },
     "/workspaces/project/{projectId}/environment/{environmentId}/availableTools": {
       "get": {
-        "operationId": "getAvailableToolsForEnvironment",
+        "operationId": "getAvailableToolsForEnvironmentInWorkspace",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -58063,7 +58015,7 @@
     },
     "/workspaces/{workspaceId}/allComments": {
       "get": {
-        "operationId": "getAllComments",
+        "operationId": "getAllWorkspaceComments",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58223,7 +58175,7 @@
     },
     "/workspaces/{workspaceId}/comment/{threadId}": {
       "delete": {
-        "operationId": "archiveComment",
+        "operationId": "archiveCommentFromThread",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58288,7 +58240,7 @@
     },
     "/workspaces/{workspaceId}/comments": {
       "get": {
-        "operationId": "getComments",
+        "operationId": "getWorkspaceComments",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58333,7 +58285,7 @@
     },
     "/workspaces/{workspaceId}/executionCheckpointStatuses": {
       "get": {
-        "operationId": "getExecutionCheckpointStatuses",
+        "operationId": "getWorkspaceExecutionCheckpointStatuses",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58511,7 +58463,7 @@
     },
     "/workspaces/{workspaceId}/logs": {
       "get": {
-        "operationId": "getLogs",
+        "operationId": "getWorkspaceLogs",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58657,7 +58609,7 @@
     },
     "/workspaces/{workspaceId}/realTimeLogs": {
       "get": {
-        "operationId": "getRealTimeLogs",
+        "operationId": "getWorkspaceRealTimeLogs",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58751,7 +58703,7 @@
     },
     "/workspaces/{workspaceId}/resourceStatuses": {
       "get": {
-        "operationId": "getWorkspaceRepositoryStatus",
+        "operationId": "getWorkspaceRepositoryResourceStatus",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -58806,7 +58758,7 @@
     },
     "/workspaces/{workspaceId}/resultFile/comments": {
       "get": {
-        "operationId": "getResultFileComments",
+        "operationId": "getWorkspaceResultFileComments",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58869,7 +58821,7 @@
     },
     "/workspaces/{workspaceId}/results": {
       "get": {
-        "operationId": "getResults",
+        "operationId": "getWorkspaceResults",
         "parameters": [
           {
             "description": "ProjectId associated with the workspace",
@@ -58924,7 +58876,7 @@
     },
     "/workspaces/{workspaceId}/runtimeExecutionDetails": {
       "get": {
-        "operationId": "getRuntimeExecutionDetails",
+        "operationId": "getWorkspaceRuntimeExecutionDetails",
         "parameters": [
           {
             "description": "ProjectId for the workspace",
@@ -59294,7 +59246,7 @@
     },
     "/workspaces/{workspaceId}/usage": {
       "get": {
-        "operationId": "getResourceUsage",
+        "operationId": "getWorkspaceResourceUsage",
         "parameters": [
           {
             "description": "ProjectId associated with the workspace",

--- a/src/conf/domino-public-api.json
+++ b/src/conf/domino-public-api.json
@@ -319,40 +319,52 @@
       "CostAllocationV1": {
         "properties": {
           "cpuCoreHours": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "cpuCoreRequestAverage": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "cpuCoreUsageAverage": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "cpuCores": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "cpuCost": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "cpuCostAdjustment": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "cpuEfficincy": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "discount": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "gpuCount": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "gpuHours": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "gpucost": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "gpucostAdjustment": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "labels": {
             "properties": {
@@ -390,10 +402,12 @@
             "type": "object"
           },
           "loadBalancerCost": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "loadBalancerCostAdjustment": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "name": {
             "type": "string"
@@ -404,25 +418,31 @@
           "pv": {
             "properties": {
               "pvByteHours": {
-                "type": "double"
+                "format": "double",
+                "type": "integer"
               },
               "pvBytes": {
-                "type": "double"
+                "format": "double",
+                "type": "integer"
               },
               "pvCost": {
-                "type": "double"
+                "format": "double",
+                "type": "integer"
               },
               "pvCostAdjustment": {
-                "type": "double"
+                "format": "double",
+                "type": "integer"
               },
               "pvs": {
                 "additionalProperties": {
                   "properties": {
                     "byteHours": {
-                      "type": "double"
+                      "format": "double",
+                      "type": "integer"
                     },
                     "cost": {
-                      "type": "double"
+                      "format": "double",
+                      "type": "integer"
                     }
                   },
                   "type": "object"
@@ -433,13 +453,16 @@
             "type": "object"
           },
           "ramCost": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "ramCostAdjustment": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "totalCost": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "window": {
             "properties": {
@@ -447,7 +470,8 @@
                 "type": "string"
               },
               "minutes": {
-                "type": "double"
+                "format": "double",
+                "type": "integer"
               },
               "start": {
                 "type": "string"
@@ -475,10 +499,12 @@
       "CostAssetsV1": {
         "properties": {
           "cpuCost": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "gpuCost": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "labels": {
             "properties": {
@@ -521,17 +547,18 @@
             "type": "object"
           },
           "ramCost": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "totalCost": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "type": {
             "type": "string"
           },
           "window": {
-            "$ref": "#/components/schemas/CostAssetsV1Window",
-            "type": "object"
+            "$ref": "#/components/schemas/CostAssetsV1Window"
           }
         },
         "type": "object"
@@ -542,7 +569,8 @@
             "type": "string"
           },
           "minutes": {
-            "type": "double"
+            "format": "double",
+            "type": "integer"
           },
           "start": {
             "type": "string"

--- a/src/conf/domino-public-api.json
+++ b/src/conf/domino-public-api.json
@@ -1,0 +1,10267 @@
+{
+  "components": {
+    "responses": {
+      "400": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FailureEnvelopeV1"
+                },
+                {
+                  "$ref": "#/components/schemas/InvalidBodyEnvelopeV1"
+                }
+              ]
+            }
+          }
+        },
+        "description": "The server could not understand the request due to malformed syntax"
+      },
+      "401": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FailureEnvelopeV1"
+            }
+          }
+        },
+        "description": "The current user cannot perform this operation because they are not logged in"
+      },
+      "403": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FailureEnvelopeV1"
+            }
+          }
+        },
+        "description": "The current user is not authorized to perform this operation"
+      },
+      "404": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FailureEnvelopeV1"
+            }
+          }
+        },
+        "description": "The server could not find the requested resource"
+      },
+      "413": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FailureEnvelopeV1"
+            }
+          }
+        },
+        "description": "Request entity is larger than limits defined by server."
+      },
+      "422": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FailureEnvelopeV1"
+            }
+          }
+        },
+        "description": "The server understands the content type of the request entity, and the syntax of the request entity is correct, but it was unable to process the contained instructions."
+      },
+      "429": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FailureEnvelopeV1"
+            }
+          }
+        },
+        "description": "The user has sent too many requests in a given amount of time."
+      },
+      "500": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/FailureEnvelopeV1"
+            }
+          }
+        },
+        "description": "An internal error prevented the server from performing this action"
+      }
+    },
+    "schemas": {
+      "AsyncPredictionEnvelopeV1": {
+        "properties": {
+          "asyncPredictionId": {
+            "description": "Id of the Async Prediction",
+            "type": "string"
+          },
+          "errors": {
+            "description": "Errors that caused the prediction to fail",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "result": {
+            "description": "The prediction result",
+            "type": "object"
+          },
+          "status": {
+            "description": "Status of the Async Prediction Request (Pending, Processing, Succeeded, Failed)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asyncPredictionId",
+          "status"
+        ],
+        "type": "object"
+      },
+      "AsyncPredictionRequestEnvelopeV1": {
+        "properties": {
+          "asyncPredictionId": {
+            "description": "Id of the created Async Prediction",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asyncPredictionId"
+        ],
+        "type": "object"
+      },
+      "AthenaBillingConfigsV1": {
+        "properties": {
+          "athenaBucketName": {
+            "type": "string"
+          },
+          "athenaDatabase": {
+            "type": "string"
+          },
+          "athenaRegion": {
+            "type": "string"
+          },
+          "athenaTable": {
+            "type": "string"
+          },
+          "projectID": {
+            "type": "string"
+          },
+          "serviceKeyName": {
+            "type": "string"
+          },
+          "serviceKeySecret": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "athenaRegion",
+          "athenaDatabase",
+          "athenaTable",
+          "athenaBucketName",
+          "projectID",
+          "serviceKeyName",
+          "serviceKeySecret"
+        ],
+        "type": "object"
+      },
+      "ClusterTypeV1": {
+        "description": "Type of compute cluster",
+        "enum": [
+          "dask",
+          "mpi",
+          "ray",
+          "spark"
+        ],
+        "type": "string"
+      },
+      "CommitDetailsV1": {
+        "properties": {
+          "inputCommitId": {
+            "description": "CommitId at execution start.",
+            "example": "f1dafe322c7d4a6720f652c330fe33b014720e46",
+            "type": "string"
+          },
+          "outputCommitId": {
+            "description": "CommitId at execution end. May be empty if execution caused no new commits.",
+            "example": "e1f06e5f64cfc26c2b70e405f70b7c8300d8a4ed",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputCommitId"
+        ],
+        "type": "object"
+      },
+      "ComputeClusterConfigV1": {
+        "properties": {
+          "clusterType": {
+            "$ref": "#/components/schemas/ClusterTypeV1"
+          },
+          "computeEnvironmentId": {
+            "description": "Id of compute environment to use.",
+            "example": "623139857a0af0281c01a6a4",
+            "type": "string"
+          },
+          "computeEnvironmentRevisionSpec": {
+            "$ref": "#/components/schemas/EnvironmentRevisionSpecV1"
+          },
+          "masterHardwareTierId": {
+            "description": "Hardware tier to use for master node in compute cluster.",
+            "example": "medium-k8s",
+            "type": "string"
+          },
+          "maxWorkerCount": {
+            "description": "Max number of workers to use in compute cluster. Enables auto-scaling for cluster when present.",
+            "example": 10,
+            "type": "integer"
+          },
+          "workerCount": {
+            "description": "Number of workers to use in compute cluster. Used as min number of workers in maxWorkerCount is set.",
+            "example": 4,
+            "type": "integer"
+          },
+          "workerHardwareTier": {
+            "description": "Hardware tier to use for workers in compute cluster.",
+            "example": "large-k8s",
+            "type": "string"
+          },
+          "workerStorageMB": {
+            "description": "Disk size in MB for each worker.",
+            "example": 5,
+            "type": "number"
+          }
+        },
+        "required": [
+          "clusterType",
+          "computeEnvironmentId",
+          "workerCount",
+          "workerHardwareTier"
+        ],
+        "type": "object"
+      },
+      "CopyProjectSpecBeta": {
+        "properties": {
+          "copyDatasets": {
+            "description": "Whether to copy the Project's datasets or not",
+            "type": "boolean"
+          },
+          "gitCodeRepoSpec": {
+            "$ref": "#/components/schemas/GitCodeRepoSpecBeta"
+          },
+          "importedGitReposCredentialId": {
+            "description": "The Domino ID of the PAT credential, which will be used to access the Imported Git Repos on the new project.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the new Domino Project.",
+            "type": "string"
+          },
+          "ownerId": {
+            "description": "The Domino ID of owner of the copied project.",
+            "type": "string"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/ProjectVisibilityV1",
+            "description": "The visibility of the new Project."
+          }
+        },
+        "required": [
+          "copyDatasets"
+        ],
+        "type": "object"
+      },
+      "CopyProjectSpecV1": {
+        "properties": {
+          "copyDatasets": {
+            "description": "Whether to copy the Project's datasets or not",
+            "type": "boolean"
+          },
+          "gitCodeRepoSpec": {
+            "$ref": "#/components/schemas/GitCodeRepoSpecV1"
+          },
+          "importedGitReposCredentialId": {
+            "description": "The Domino ID of the PAT credential, which will be used to access the Imported Git Repos on the new project.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the new Domino Project.",
+            "type": "string"
+          },
+          "ownerId": {
+            "description": "The Domino ID of owner of the copied project.",
+            "type": "string"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/ProjectVisibilityV1",
+            "description": "The visibility of the new Project."
+          }
+        },
+        "required": [
+          "copyDatasets"
+        ],
+        "type": "object"
+      },
+      "CostAllocationEnvelopeV1": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/CostAllocationV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "CostAllocationV1": {
+        "properties": {
+          "cpuCoreHours": {
+            "type": "double"
+          },
+          "cpuCoreRequestAverage": {
+            "type": "double"
+          },
+          "cpuCoreUsageAverage": {
+            "type": "double"
+          },
+          "cpuCores": {
+            "type": "double"
+          },
+          "cpuCost": {
+            "type": "double"
+          },
+          "cpuCostAdjustment": {
+            "type": "double"
+          },
+          "cpuEfficincy": {
+            "type": "double"
+          },
+          "discount": {
+            "type": "double"
+          },
+          "gpuCount": {
+            "type": "double"
+          },
+          "gpuHours": {
+            "type": "double"
+          },
+          "gpucost": {
+            "type": "double"
+          },
+          "gpucostAdjustment": {
+            "type": "double"
+          },
+          "labels": {
+            "properties": {
+              "organization_id": {
+                "type": "string"
+              },
+              "organization_name": {
+                "type": "string"
+              },
+              "project_id": {
+                "type": "string"
+              },
+              "project_name": {
+                "type": "string"
+              },
+              "project_owner_id": {
+                "type": "string"
+              },
+              "project_owner_name": {
+                "type": "string"
+              },
+              "starting_user_id": {
+                "type": "string"
+              },
+              "starting_user_name": {
+                "type": "string"
+              },
+              "workload_id": {
+                "type": "string"
+              },
+              "workload_type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "loadBalancerCost": {
+            "type": "double"
+          },
+          "loadBalancerCostAdjustment": {
+            "type": "double"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nodeType": {
+            "type": "string"
+          },
+          "pv": {
+            "properties": {
+              "pvByteHours": {
+                "type": "double"
+              },
+              "pvBytes": {
+                "type": "double"
+              },
+              "pvCost": {
+                "type": "double"
+              },
+              "pvCostAdjustment": {
+                "type": "double"
+              },
+              "pvs": {
+                "additionalProperties": {
+                  "properties": {
+                    "byteHours": {
+                      "type": "double"
+                    },
+                    "cost": {
+                      "type": "double"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "ramCost": {
+            "type": "double"
+          },
+          "ramCostAdjustment": {
+            "type": "double"
+          },
+          "totalCost": {
+            "type": "double"
+          },
+          "window": {
+            "properties": {
+              "end": {
+                "type": "string"
+              },
+              "minutes": {
+                "type": "double"
+              },
+              "start": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "CostAssetsEnvelopeV1": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/CostAssetsV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "CostAssetsV1": {
+        "properties": {
+          "cpuCost": {
+            "type": "double"
+          },
+          "gpuCost": {
+            "type": "double"
+          },
+          "labels": {
+            "properties": {
+              "instance": {
+                "type": "string"
+              },
+              "job": {
+                "type": "string"
+              },
+              "label_dominodatalab_com_domino_node": {
+                "type": "string"
+              },
+              "label_dominodatalab_com_node_pool": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "properties": {
+              "category": {
+                "type": "string"
+              },
+              "cluster": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "providerId": {
+                "type": "string"
+              },
+              "service": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "ramCost": {
+            "type": "double"
+          },
+          "totalCost": {
+            "type": "double"
+          },
+          "type": {
+            "type": "string"
+          },
+          "window": {
+            "$ref": "#/components/schemas/CostAssetsV1Window",
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "CostAssetsV1Window": {
+        "properties": {
+          "end": {
+            "type": "string"
+          },
+          "minutes": {
+            "type": "double"
+          },
+          "start": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DataSourceAuditDataV1": {
+        "properties": {
+          "dataSourceId": {
+            "description": "ID of the datasource",
+            "type": "string"
+          },
+          "dataSourceName": {
+            "description": "name of the datasource",
+            "type": "string"
+          },
+          "dataSourceType": {
+            "description": "type of the datasource",
+            "type": "string"
+          },
+          "eventKind": {
+            "$ref": "#/components/schemas/DataSourceAuditEventKindV1"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/DataSourceAuditMetadataV1"
+          },
+          "performedBy": {
+            "description": "username of user who performed the event",
+            "type": "string"
+          },
+          "timestamp": {
+            "description": "timestamp of when event was performed",
+            "example": "1996-07-19T03:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "dataSourceId",
+          "dataSourceName",
+          "dataSourceType",
+          "eventKind",
+          "metadata",
+          "performedBy",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "DataSourceAuditEventKindV1": {
+        "description": "Kinds of datasource audit events",
+        "enum": [
+          "AccessDataSource",
+          "CreateDataSource",
+          "DataSourceAssociatedToProject",
+          "DataSourceDissociatedFromProject",
+          "DataSourceChangeOfOwnership",
+          "DataSourceChangeOfPermissions",
+          "DeleteDataSource"
+        ],
+        "type": "string"
+      },
+      "DataSourceAuditMetadataV1": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "A map of string -> string",
+        "example": {
+          "foo": "bar"
+        },
+        "type": "object"
+      },
+      "DatasetInfoV1": {
+        "properties": {
+          "createdAt": {
+            "description": "When the dataset was created",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "description": {
+            "description": "A description of the dataset",
+            "type": "string"
+          },
+          "id": {
+            "description": "Dataset ID",
+            "example": "62313ce67a0af0281c01a6a5",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the dataset",
+            "example": "My Dataset",
+            "type": "string"
+          },
+          "projectId": {
+            "description": "ID of the project this dataset belongs to",
+            "example": "62313ce67a0af0281c01a6a5",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "DatasetMountV1": {
+        "properties": {
+          "containerPath": {
+            "description": "Location dataset is mounted at in the Job.",
+            "example": "/domino/datasets/local/quick-start",
+            "type": "string"
+          },
+          "datasetName": {
+            "description": "Name of dataset to be mounted.",
+            "example": "MyDataset",
+            "type": "string"
+          },
+          "id": {
+            "description": "Id of dataset to be mounted.",
+            "example": "623137f57a0af0281c01a6a0",
+            "type": "string"
+          },
+          "isInput": {
+            "description": "Whether a dataset was an input to be used in the execution, or an output created by the execution.",
+            "example": true,
+            "type": "boolean"
+          },
+          "projectId": {
+            "description": "Id of project the dataset belongs to.",
+            "example": "6231383c7a0af0281c01a6a1",
+            "type": "string"
+          },
+          "snapshotId": {
+            "description": "Id of snapshot to mount for this dataset.",
+            "example": "623138807a0af0281c01a6a2",
+            "type": "string"
+          },
+          "snapshotVersion": {
+            "description": "Version of dataset snapshot to mound.",
+            "example": 2,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "datasetName",
+          "projectId",
+          "isInput"
+        ],
+        "type": "object"
+      },
+      "DatasetNotCopiedV1": {
+        "properties": {
+          "datasetInfo": {
+            "$ref": "#/components/schemas/DatasetInfoV1",
+            "description": "dataset not copied"
+          },
+          "errorMessage": {
+            "description": "error message explaining why dataset wasn't copied",
+            "type": "string"
+          }
+        },
+        "required": [
+          "datasetInfo",
+          "errorMessage"
+        ],
+        "type": "object"
+      },
+      "DatasetRwDetailsV1": {
+        "properties": {
+          "createdAt": {
+            "description": "When the dataset was created",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "description": {
+            "description": "A description of the dataset",
+            "type": "string"
+          },
+          "id": {
+            "description": "ID of the dataset",
+            "example": "62313ce67a0af0281c01a6a5",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the dataset",
+            "example": "My Dataset",
+            "type": "string"
+          },
+          "projectId": {
+            "description": "ID of the project this dataset belongs to",
+            "example": "62313ce67a0af0281c01a6a5",
+            "type": "string"
+          },
+          "snapshotIds": {
+            "description": "List of snapshot IDs belonging to this dataset",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/DatasetRwTagsV1"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "createdAt",
+          "snapshotIds",
+          "tags"
+        ],
+        "type": "object"
+      },
+      "DatasetRwEnvelopeV1": {
+        "properties": {
+          "dataset": {
+            "$ref": "#/components/schemas/DatasetRwDetailsV1"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "dataset",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "DatasetRwGrantDetailsEnvelopeV1": {
+        "properties": {
+          "grantDetails": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetRwGrantDetailsV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "grantDetails",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "DatasetRwGrantDetailsV1": {
+        "properties": {
+          "isOrganization": {
+            "description": "If target id is an organization",
+            "type": "boolean"
+          },
+          "targetId": {
+            "description": "ID of the user within the grant",
+            "type": "string"
+          },
+          "targetName": {
+            "description": "Username of user within the grant",
+            "type": "string"
+          },
+          "targetRole": {
+            "$ref": "#/components/schemas/DatasetRwRoleV1"
+          }
+        },
+        "required": [
+          "targetId",
+          "targetName",
+          "targetRole",
+          "isOrganization"
+        ],
+        "type": "object"
+      },
+      "DatasetRwGrantEnvelopeV1": {
+        "properties": {
+          "grants": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetRwGrantV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "grants",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "DatasetRwGrantV1": {
+        "properties": {
+          "targetId": {
+            "description": "ID of the user within the grant",
+            "type": "string"
+          },
+          "targetRole": {
+            "$ref": "#/components/schemas/DatasetRwRoleV1"
+          }
+        },
+        "required": [
+          "targetId",
+          "targetRole"
+        ],
+        "type": "object"
+      },
+      "DatasetRwInfoDtoV1": {
+        "properties": {
+          "dataset": {
+            "$ref": "#/components/schemas/DatasetRwDetailsV1"
+          },
+          "projectInfo": {
+            "$ref": "#/components/schemas/DatasetRwProjectInfoDtoV1"
+          }
+        },
+        "required": [
+          "dataset"
+        ],
+        "type": "object"
+      },
+      "DatasetRwMetadataV1": {
+        "properties": {
+          "description": {
+            "description": "Description of the dataset",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of this dataset. The name must be unique in the same project",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DatasetRwPermissionV1": {
+        "description": "Permission within a dataset",
+        "enum": [
+          "DeleteDatasetRwV2",
+          "EditSecurityDatasetRwV2",
+          "ListDatasetRwV2",
+          "PerformDatasetRwActionsInProjectV2",
+          "PermanentDeleteDatasetRwV2",
+          "ReadDatasetRwV2",
+          "UpdateDatasetRwV2",
+          "PerformDatasetRwActionsAsAdminV2"
+        ],
+        "type": "string"
+      },
+      "DatasetRwProjectInfoDtoV1": {
+        "properties": {
+          "projectId": {
+            "description": "ID of the project this dataset belongs to",
+            "type": "string"
+          },
+          "projectName": {
+            "description": "Name of the project this dataset belongs to",
+            "type": "string"
+          },
+          "projectOwnerUsername": {
+            "description": "Username of the project's owner",
+            "type": "string"
+          }
+        },
+        "required": [
+          "projectId",
+          "projectName",
+          "projectOwnerUsername"
+        ],
+        "type": "object"
+      },
+      "DatasetRwRoleV1": {
+        "description": "Role that the user will assume in the dataset. Note that organizations cannot be dataset Owners",
+        "enum": [
+          "DatasetRwOwner",
+          "DatasetRwEditor",
+          "DatasetRwReader"
+        ],
+        "type": "string"
+      },
+      "DatasetRwTagToAddV1": {
+        "properties": {
+          "snapshotId": {
+            "description": "ID of a snapshot belonging to the dataset",
+            "example": "62313ce67a0af0281c01a6a5",
+            "type": "string"
+          },
+          "tagName": {
+            "description": "Name of tag to add to a snapshot",
+            "example": "MyTag",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tagName",
+          "snapshotId"
+        ],
+        "type": "object"
+      },
+      "DatasetRwTagsV1": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "A map of tagName -> snapshotId",
+        "example": {
+          "bar": "62313ce67a0af0281c01a6a5",
+          "foo": "62313ce67a0af0281c01a6a5"
+        },
+        "type": "object"
+      },
+      "DatasetToAddV1": {
+        "properties": {
+          "datasetId": {
+            "description": "ID of shared dataset to link with this project",
+            "example": "62313ce67a0af0281c01a6a5",
+            "type": "string"
+          }
+        },
+        "required": [
+          "datasetId"
+        ],
+        "type": "object"
+      },
+      "DeepCopyGitRepoSpecBeta": {
+        "description": "Data which specifies what the copied repository will look like.",
+        "properties": {
+          "isPrivate": {
+            "description": "Whether or not the new code repo should be private.",
+            "type": "boolean"
+          },
+          "newRepoName": {
+            "description": "The name of the new repository.",
+            "type": "string"
+          },
+          "newRepoOwnerName": {
+            "description": "The name of the user who will own the new repository in the git service provider.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "newRepoName",
+          "newRepoOwnerName",
+          "isPrivate"
+        ],
+        "type": "object"
+      },
+      "DeepCopyGitRepoSpecV1": {
+        "description": "Data which specifies what the copied repository will look like.",
+        "properties": {
+          "newRepoName": {
+            "description": "The name of the new repository.",
+            "type": "string"
+          },
+          "newRepoOwnerName": {
+            "description": "The name of the user who will own the new repository in the git service provider.",
+            "type": "string"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/ProviderRepoVisibilityV1"
+          }
+        },
+        "required": [
+          "newRepoName",
+          "newRepoOwnerName",
+          "visibility"
+        ],
+        "type": "object"
+      },
+      "DeleteEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "DominoStatsV1": {
+        "properties": {
+          "name": {
+            "description": "The key name in the domino stats.",
+            "example": "R-squared",
+            "type": "string"
+          },
+          "value": {
+            "description": "The value for the key in the domino stats",
+            "example": 0.89,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ],
+        "type": "object"
+      },
+      "EnvironmentEnvelopeV1": {
+        "properties": {
+          "environment": {
+            "$ref": "#/components/schemas/EnvironmentV1"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "environment",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "EnvironmentOwnerTypeV1": {
+        "description": "Type of owner for an Environment. Environments can either be owned by a normal user or by an Organization.",
+        "enum": [
+          "individual",
+          "organization"
+        ],
+        "type": "string"
+      },
+      "EnvironmentOwnerV1": {
+        "properties": {
+          "id": {
+            "description": "Id of owner of an environment.",
+            "example": "6231327c7a0af0281c01a69b",
+            "type": "string"
+          },
+          "ownerType": {
+            "$ref": "#/components/schemas/EnvironmentOwnerTypeV1"
+          },
+          "username": {
+            "description": "Username of owner of an environment.",
+            "example": "OrgOwner",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "ownerType"
+        ],
+        "type": "object"
+      },
+      "EnvironmentRevisionBuildStatusV1": {
+        "description": "Status of the build for an Environment Revision.",
+        "enum": [
+          "queued",
+          "starting",
+          "pulling",
+          "building",
+          "pushing",
+          "succeeded",
+          "failed",
+          "killed"
+        ],
+        "type": "string"
+      },
+      "EnvironmentRevisionEnvelopeV1": {
+        "properties": {
+          "environmentRevision": {
+            "$ref": "#/components/schemas/EnvironmentRevisionV1"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "environmentRevision",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "EnvironmentRevisionSpecV1": {
+        "description": "Specification describing which environment revision to use. Defaults to \"ActiveRevision\"",
+        "example": "ActiveRevision | LatestRevision | SomeRevision(623131577a0af0281c01a69a)",
+        "type": "string"
+      },
+      "EnvironmentRevisionUpdateEnvelopeV1": {
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "EnvironmentRevisionV1": {
+        "properties": {
+          "availableTools": {
+            "items": {
+              "$ref": "#/components/schemas/EnvironmentToolV1"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "Id of Environment Revision.",
+            "example": "62313cfd7a0af0281c01a6a6",
+            "type": "string"
+          },
+          "number": {
+            "description": "Revision number, increasing sequentially with each revision.",
+            "example": 4,
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/components/schemas/EnvironmentRevisionBuildStatusV1"
+          }
+        },
+        "required": [
+          "id",
+          "number",
+          "availableTools"
+        ],
+        "type": "object"
+      },
+      "EnvironmentToolV1": {
+        "properties": {
+          "iconUrl": {
+            "description": "Url to pull icon image from",
+            "example": "/assets/images/workspace-logos/Jupyter.svg",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of environment tool",
+            "example": "Jupyter",
+            "type": "string"
+          },
+          "proxyConfig": {
+            "$ref": "#/components/schemas/ProxyConfigV1"
+          },
+          "startScripts": {
+            "items": {
+              "description": "Scripts to run on workspace start.",
+              "example": "echo hello",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "supportedFileExtensions": {
+            "items": {
+              "description": "File extensions this tool supports.",
+              "example": ".ipynb",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": {
+            "description": "Title of environment tool.",
+            "example": "Jupyter",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "title",
+          "startScripts"
+        ],
+        "type": "object"
+      },
+      "EnvironmentV1": {
+        "properties": {
+          "activeRevisionTags": {
+            "description": "The tags on the active revision for this environment",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "archived": {
+            "description": "Whether the environment is archived",
+            "example": false,
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Id of environment",
+            "example": "623132867a0af0281c01a69c",
+            "type": "string"
+          },
+          "internalTags": {
+            "description": "The internal tags specifying if this environment is restricted",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "isCurated": {
+            "description": "Whether or not the environment is curated for a deployment",
+            "type": "boolean"
+          },
+          "latestRevision": {
+            "$ref": "#/components/schemas/EnvironmentRevisionV1"
+          },
+          "name": {
+            "example": "MyOrg",
+            "type": "string"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/EnvironmentOwnerV1"
+          },
+          "restrictedRevision": {
+            "$ref": "#/components/schemas/EnvironmentRevisionV1"
+          },
+          "selectedRevision": {
+            "$ref": "#/components/schemas/EnvironmentRevisionV1"
+          },
+          "supportedClusters": {
+            "items": {
+              "$ref": "#/components/schemas/ClusterTypeV1"
+            },
+            "type": "array"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/EnvironmentVisibilityV1"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "visibility",
+          "supportedClusters",
+          "archived"
+        ],
+        "type": "object"
+      },
+      "EnvironmentVariableV1": {
+        "description": "Key-value pair that defines an environment variable name and value",
+        "properties": {
+          "key": {
+            "example": "USERNAME",
+            "type": "string"
+          },
+          "value": {
+            "example": "my_name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "EnvironmentVisibilityV1": {
+        "description": "Visiblity of an environment. Private Environments are only visible to the creating user, whereas Organization owned Environments can be seen by all Org members.",
+        "enum": [
+          "global",
+          "private",
+          "organization"
+        ],
+        "type": "string"
+      },
+      "ExternalVolumeMountV1": {
+        "properties": {
+          "mountPath": {
+            "description": "Path to mount the external volume at.",
+            "example": "/path/to/my/volume",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of external volume to mount.",
+            "example": "MyExternalVolume",
+            "type": "string"
+          },
+          "readOnly": {
+            "description": "Whether to mount the volume as read only.",
+            "example": false,
+            "type": "boolean"
+          },
+          "subPath": {
+            "description": "Path within the external volume to mount. The entire volume will be mounted if not specified.",
+            "example": "/mypath",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "mountPath",
+          "readOnly"
+        ],
+        "type": "object"
+      },
+      "FailureEnvelopeV1": {
+        "properties": {
+          "errors": {
+            "description": "Errors that caused a request to fail",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "requestId": {
+            "description": "Id used to correlate a request with server actions.",
+            "example": "bbd78579-93c4-45ee-a983-0d5c8da6d5b1",
+            "type": "string"
+          }
+        },
+        "required": [
+          "requestId",
+          "errors"
+        ],
+        "type": "object"
+      },
+      "GitCodeRepoSpecBeta": {
+        "description": "Details needed in order to copy the code repository of a Git-backed project.",
+        "properties": {
+          "credentialId": {
+            "description": "The Domino ID of the PAT credential, which will be used to copy and/or read from the code repository on the new project.",
+            "type": "string"
+          },
+          "deepCopy": {
+            "$ref": "#/components/schemas/DeepCopyGitRepoSpecBeta"
+          },
+          "referenceCopy": {
+            "$ref": "#/components/schemas/ReferenceCopyGitRepoSpecV1"
+          }
+        },
+        "required": [
+          "credentialId"
+        ],
+        "type": "object"
+      },
+      "GitCodeRepoSpecV1": {
+        "description": "Details needed in order to copy the code repository of a Git-backed project.",
+        "properties": {
+          "credentialId": {
+            "description": "The Domino ID of the PAT credential, which will be used to copy and/or read from the code repository on the new project.",
+            "type": "string"
+          },
+          "deepCopy": {
+            "$ref": "#/components/schemas/DeepCopyGitRepoSpecV1"
+          },
+          "referenceCopy": {
+            "$ref": "#/components/schemas/ReferenceCopyGitRepoSpecV1"
+          }
+        },
+        "required": [
+          "credentialId"
+        ],
+        "type": "object"
+      },
+      "GitCredentialsAccessorV1": {
+        "properties": {
+          "domain": {
+            "description": "The domain these credentials apply to",
+            "example": "github.com",
+            "type": "string"
+          },
+          "fingerprint": {
+            "example": "ba:78:09:d8:4b:3b:09:9b:43:bf:9b:5a:34:f7:3f:28",
+            "type": "string"
+          },
+          "gitServiceProvider": {
+            "$ref": "#/components/schemas/GitServiceProviderV1"
+          },
+          "id": {
+            "description": "Id for these git credentials",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name for these git credentials",
+            "example": "My creds",
+            "type": "string"
+          },
+          "protocol": {
+            "example": "https",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "gitServiceProvider",
+          "domain",
+          "fingerprint",
+          "protocol"
+        ],
+        "type": "object"
+      },
+      "GitRefV1": {
+        "properties": {
+          "refType": {
+            "description": "The type of git reference being used.",
+            "example": "head | commitId | tags | branches",
+            "type": "string"
+          },
+          "value": {
+            "description": "The value of the git reference. Only necessary for relevant git ref types.",
+            "example": "my-test-branch",
+            "type": "string"
+          }
+        },
+        "required": [
+          "refType"
+        ],
+        "type": "object"
+      },
+      "GitReferenceTypeV1": {
+        "enum": [
+          "head",
+          "branch",
+          "tag",
+          "commit"
+        ],
+        "type": "string"
+      },
+      "GitServiceProviderV1": {
+        "description": "Git service provider",
+        "enum": [
+          "bitbucket",
+          "bitbucketServer",
+          "github",
+          "githubEnterprise",
+          "gitLab",
+          "gitLabEnterprise",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "GoalEnvelopeV1": {
+        "properties": {
+          "goal": {
+            "$ref": "#/components/schemas/LinkedGoalV1"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "goal",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "GoalToLinkV1": {
+        "properties": {
+          "goalId": {
+            "description": "Id of Goal to link to Job.",
+            "example": "62313cfd7a0af0281c01a6a6",
+            "type": "string"
+          },
+          "projectId": {
+            "description": "Id of project resources belong to.",
+            "example": "62313d377a0af0281c01a6a8",
+            "type": "string"
+          }
+        },
+        "required": [
+          "goalId",
+          "projectId"
+        ],
+        "type": "object"
+      },
+      "HealthCheck": {
+        "properties": {
+          "commit": {
+            "type": "string"
+          },
+          "kubecostStatus": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "version"
+        ],
+        "type": "object"
+      },
+      "InvalidBodyEnvelopeV1": {
+        "properties": {
+          "message": {
+            "description": "Error message when request is missing a required field and therefore cannot be handled.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "JobDetailsV1": {
+        "properties": {
+          "commentsCount": {
+            "type": "integer"
+          },
+          "commitDetails": {
+            "$ref": "#/components/schemas/CommitDetailsV1"
+          },
+          "computeCluster": {
+            "$ref": "#/components/schemas/ComputeClusterConfigV1"
+          },
+          "datasetMounts": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetMountV1"
+            },
+            "type": "array"
+          },
+          "dominoStats": {
+            "items": {
+              "$ref": "#/components/schemas/DominoStatsV1"
+            },
+            "type": "array"
+          },
+          "externalVolumeMounts": {
+            "items": {
+              "$ref": "#/components/schemas/ExternalVolumeMountV1"
+            },
+            "type": "array"
+          },
+          "gitRepos": {
+            "items": {
+              "$ref": "#/components/schemas/MountedGitRepoV1"
+            },
+            "type": "array"
+          },
+          "goalIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "mainRepoGitRef": {
+            "$ref": "#/components/schemas/GitRefV1"
+          },
+          "number": {
+            "type": "integer"
+          },
+          "projects": {
+            "items": {
+              "$ref": "#/components/schemas/MountedProjectV1"
+            },
+            "type": "array"
+          },
+          "queuedJobStatusDetails": {
+            "$ref": "#/components/schemas/QueuedJobStatusDetailsV1"
+          },
+          "runCommand": {
+            "type": "string"
+          },
+          "runLauncherId": {
+            "type": "string"
+          },
+          "stageTimes": {
+            "$ref": "#/components/schemas/StageTimesV1"
+          },
+          "startedById": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/JobStatusV1"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagV1"
+            },
+            "type": "array"
+          },
+          "title": {
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/JobUsageV1"
+          }
+        },
+        "required": [
+          "id",
+          "number",
+          "stageTimes",
+          "tags",
+          "runCommand",
+          "commentsCount",
+          "commitDetails",
+          "dominoStats",
+          "status",
+          "projects",
+          "gitRepos",
+          "datasetMounts",
+          "externalVolumeMounts",
+          "goalIds"
+        ],
+        "type": "object"
+      },
+      "JobEnvelopeV1": {
+        "properties": {
+          "job": {
+            "$ref": "#/components/schemas/JobDetailsV1"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "job",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "JobLogsV1": {
+        "properties": {
+          "helpLink": {
+            "description": "Suggestion link for helpful resources.",
+            "example": "Error. No such file or directory.",
+            "type": "string"
+          },
+          "isComplete": {
+            "description": "Whether all logs for the job have been retrieved.",
+            "example": true,
+            "type": "boolean"
+          },
+          "logContent": {
+            "items": {
+              "$ref": "#/components/schemas/LogContentV1"
+            },
+            "type": "array"
+          },
+          "problem": {
+            "description": "Description of issue that occurred in a job.",
+            "example": "python: can't open file 'invalid.py': [Errno 2] No such file or directory",
+            "type": "string"
+          }
+        },
+        "required": [
+          "logContent",
+          "isComplete"
+        ],
+        "type": "object"
+      },
+      "JobStatusV1": {
+        "properties": {
+          "executionStatus": {
+            "description": "Current status of the job.",
+            "example": "Succeeded",
+            "type": "string"
+          },
+          "isArchived": {
+            "description": "Whether a job is archived.",
+            "example": false,
+            "type": "boolean"
+          },
+          "isCompleted": {
+            "description": "Whether a job is complete.",
+            "example": true,
+            "type": "boolean"
+          },
+          "isScheduled": {
+            "description": "Whether a job was started by a scheduled trigger.",
+            "example": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "isCompleted",
+          "isArchived",
+          "isScheduled",
+          "executionStatus"
+        ],
+        "type": "object"
+      },
+      "JobUsageV1": {
+        "properties": {
+          "cpuPercentage": {
+            "description": "Max cpu usage for a job as a percentage of the total available cpu.",
+            "example": 5,
+            "type": "number"
+          },
+          "memoryGiB": {
+            "description": "Max memory usage for a job in GiB.",
+            "example": 0.73,
+            "type": "number"
+          }
+        },
+        "required": [
+          "cpuPercentage",
+          "memoryGiB"
+        ],
+        "type": "object"
+      },
+      "JobV1": {
+        "properties": {
+          "commitDetails": {
+            "$ref": "#/components/schemas/CommitDetailsV1"
+          },
+          "computeCluster": {
+            "$ref": "#/components/schemas/ComputeClusterConfigV1"
+          },
+          "datasetMounts": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetMountV1"
+            },
+            "type": "array"
+          },
+          "dominoStats": {
+            "items": {
+              "$ref": "#/components/schemas/DominoStatsV1"
+            },
+            "type": "array"
+          },
+          "externalVolumeMounts": {
+            "items": {
+              "$ref": "#/components/schemas/ExternalVolumeMountV1"
+            },
+            "type": "array"
+          },
+          "gitRepos": {
+            "items": {
+              "$ref": "#/components/schemas/MountedGitRepoV1"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "mainRepoGitRef": {
+            "$ref": "#/components/schemas/GitRefV1"
+          },
+          "number": {
+            "type": "integer"
+          },
+          "projects": {
+            "items": {
+              "$ref": "#/components/schemas/MountedProjectV1"
+            },
+            "type": "array"
+          },
+          "runCommand": {
+            "type": "string"
+          },
+          "runLauncherId": {
+            "type": "string"
+          },
+          "stageTimes": {
+            "$ref": "#/components/schemas/StageTimesV1"
+          },
+          "startedById": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/JobStatusV1"
+          },
+          "title": {
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/JobUsageV1"
+          }
+        },
+        "required": [
+          "id",
+          "number",
+          "stageTimes",
+          "runCommand",
+          "commitDetails",
+          "dominoStats",
+          "status",
+          "projects",
+          "gitRepos",
+          "datasetMounts",
+          "externalVolumeMounts"
+        ],
+        "type": "object"
+      },
+      "KubecostLicenseResponseV1": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "key": {
+            "description": "License Key set on Kubecost",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "KubecostLicenseV1": {
+        "properties": {
+          "key": {
+            "description": "License Key to be set on Kubecost",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "type": "object"
+      },
+      "LinkedGoalV1": {
+        "properties": {
+          "currentStage": {
+            "description": "The stage this goal is currently assigned.",
+            "example": "Ideation",
+            "type": "string"
+          },
+          "description": {
+            "description": "Description of the Goal.",
+            "example": "Develop a better performing model",
+            "type": "string"
+          },
+          "goalId": {
+            "description": "Id of Goal linked to Job.",
+            "example": "62313cfd7a0af0281c01a6a6",
+            "type": "string"
+          },
+          "jobId": {
+            "description": "Id of Job linked to Goal.",
+            "example": "62313d207a0af0281c01a6a7",
+            "type": "string"
+          },
+          "projectId": {
+            "description": "Id of project resources belong to.",
+            "example": "62313d377a0af0281c01a6a8",
+            "type": "string"
+          },
+          "title": {
+            "description": "Name of goal.",
+            "example": "MyGoal",
+            "type": "string"
+          }
+        },
+        "required": [
+          "goalId",
+          "jobId",
+          "projectId",
+          "title",
+          "currentStage"
+        ],
+        "type": "object"
+      },
+      "LogContentV1": {
+        "properties": {
+          "log": {
+            "description": "Log message",
+            "example": "Pulling image \"172.20.22.242:5000/noahjax11699-compute/environment:622a6879dde1a920fcccfef5-1\"",
+            "type": "string"
+          },
+          "logType": {
+            "$ref": "#/components/schemas/LogTypeV1"
+          },
+          "size": {
+            "description": "Length of log line.",
+            "example": 94,
+            "type": "integer"
+          },
+          "timestamp": {
+            "description": "Time logs were written.",
+            "example": "2022-03-12T02:13:51.616Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "timestamp",
+          "logType",
+          "log",
+          "size"
+        ],
+        "type": "object"
+      },
+      "LogTypeV1": {
+        "description": "Type of log. Complete includes all log types.",
+        "enum": [
+          "stdOut",
+          "stdErr",
+          "prepareOutput",
+          "complete"
+        ],
+        "type": "string"
+      },
+      "LogsEnvelopeV1": {
+        "properties": {
+          "logs": {
+            "$ref": "#/components/schemas/JobLogsV1"
+          },
+          "metadata": {
+            "properties": {
+              "notices": {
+                "description": "Notices relating to the request",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "pagination": {
+                "$ref": "#/components/schemas/LogsPaginationV1"
+              },
+              "requestId": {
+                "description": "Id used to correlate a request with server actions.",
+                "example": "bbd78579-93c4-45ee-a983-0d5c8da6d5b1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "pagination",
+              "requestId",
+              "notices"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "logs",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "LogsPaginationV1": {
+        "properties": {
+          "latestTimeNano": {
+            "description": "Time of last log. Can be used to specify only logs after a certain time.",
+            "example": "1647051415275957459",
+            "type": "string"
+          },
+          "limit": {
+            "description": "Max number of log messages to retrieve.",
+            "example": 10,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "limit"
+        ],
+        "type": "object"
+      },
+      "MetadataV1": {
+        "properties": {
+          "notices": {
+            "description": "Notices relating to the request",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "requestId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "requestId",
+          "notices"
+        ],
+        "type": "object"
+      },
+      "MetricAlertRequestV1": {
+        "properties": {
+          "description": {
+            "description": "Optional text to append to the metric alert message",
+            "type": "string"
+          },
+          "metric": {
+            "description": "Name of the metric to send alert for",
+            "type": "string"
+          },
+          "modelMonitoringId": {
+            "description": "ID of the monitored model to send metric alerts for",
+            "type": "string"
+          },
+          "targetRange": {
+            "$ref": "#/components/schemas/TargetRangeV1"
+          },
+          "value": {
+            "description": "Value of the metric",
+            "type": "number"
+          }
+        },
+        "required": [
+          "modelMonitoringId",
+          "metric",
+          "value",
+          "targetRange"
+        ],
+        "type": "object"
+      },
+      "MetricTagV1": {
+        "properties": {
+          "key": {
+            "description": "Key for the metric tag",
+            "type": "string"
+          },
+          "value": {
+            "description": "Value for the metric tag",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "MetricValueV1": {
+        "properties": {
+          "referenceTimestamp": {
+            "description": "Timestamp associated with the metric log entry",
+            "type": "string"
+          },
+          "tags": {
+            "description": "List of tags associated with the metric",
+            "items": {
+              "$ref": "#/components/schemas/MetricTagV1"
+            },
+            "type": "array"
+          },
+          "value": {
+            "description": "Value of the metric",
+            "type": "number"
+          }
+        },
+        "required": [
+          "value",
+          "referenceTimestamp",
+          "tags"
+        ],
+        "type": "object"
+      },
+      "MetricValuesEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "metricValues": {
+            "items": {
+              "$ref": "#/components/schemas/MetricValueV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "metricValues",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "MountedGitRepoV1": {
+        "properties": {
+          "endingBranch": {
+            "description": "Branch this git repo ended at.",
+            "example": "final-branch",
+            "type": "string"
+          },
+          "endingCommitId": {
+            "description": "Ending commitId for this git repo.",
+            "example": "dff155c9a736f9cd230eac420e3c1ef3daa0ad7e",
+            "type": "string"
+          },
+          "id": {
+            "description": "Id of the git repo mounted to the Job.",
+            "example": "6231365e7a0af0281c01a69f",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the git repo mounted to the Job.",
+            "example": "MyRepo",
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "serviceProvider": {
+            "$ref": "#/components/schemas/GitServiceProviderV1"
+          },
+          "startingBranch": {
+            "description": "Branch this git repo started at.",
+            "example": "init-test-branch",
+            "type": "string"
+          },
+          "startingCommitId": {
+            "description": "CommitId the git repo should be mounted at.",
+            "example": "4f2d5c2f54db4fbb16a093d4fb11fdb1fe0794c7",
+            "type": "string"
+          },
+          "uri": {
+            "description": "Uri for the repo being mounted.",
+            "example": "git@github.com:apache/spark.git",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "uri",
+          "ref",
+          "serviceProvider"
+        ],
+        "type": "object"
+      },
+      "MountedProjectV1": {
+        "properties": {
+          "commitId": {
+            "description": "CommitId to use for project being mounted.",
+            "example": "7f8e3908f129c0ca6529028618e6f10b3d2f315a",
+            "type": "string"
+          },
+          "projectId": {
+            "description": "Id of project to mount.",
+            "example": "623138c87a0af0281c01a6a3",
+            "type": "string"
+          }
+        },
+        "required": [
+          "projectId",
+          "commitId"
+        ],
+        "type": "object"
+      },
+      "NewAsyncPredictionV1": {
+        "properties": {
+          "parameters": {
+            "description": "Parameters that will be passed to Async Model predict function",
+            "type": "object"
+          }
+        },
+        "required": [
+          "parameters"
+        ],
+        "type": "object"
+      },
+      "NewDatasetRwV1": {
+        "properties": {
+          "description": {
+            "description": "Description of the dataset",
+            "type": "string"
+          },
+          "grants": {
+            "description": "Permission grants to be assigned for this newly created dataset. Note that permissions can be edited after creation. If snapshotId is passed in, this parameter won't have any effect and caller will be assigned dataset Ownership.",
+            "items": {
+              "$ref": "#/components/schemas/DatasetRwGrantV1"
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "Name of this dataset. The name must be unique in the same project",
+            "type": "string"
+          },
+          "projectId": {
+            "description": "ID of the project this dataset belongs to. Either projectId or snapshotId must be provided",
+            "type": "string"
+          },
+          "snapshotId": {
+            "description": "ID of an existing snapshot to create a new dataset from. Either snapshotId or projectId must be provided.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "NewEnvironmentRevisionV1": {
+        "properties": {
+          "dockerfileInstructions": {
+            "type": "string"
+          },
+          "environmentVariables": {
+            "items": {
+              "$ref": "#/components/schemas/EnvironmentVariableV1"
+            },
+            "type": "array"
+          },
+          "image": {
+            "description": "Environment revision image. Required for creating a new environment",
+            "type": "string"
+          },
+          "postRunScript": {
+            "type": "string"
+          },
+          "postSetupScript": {
+            "type": "string"
+          },
+          "preRunScript": {
+            "type": "string"
+          },
+          "preSetupScript": {
+            "type": "string"
+          },
+          "skipCache": {
+            "type": "boolean"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "supportedClusters": {
+            "items": {
+              "$ref": "#/components/schemas/ClusterTypeV1"
+            },
+            "type": "array"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "useVpn": {
+            "type": "boolean"
+          },
+          "workspaceTools": {
+            "items": {
+              "$ref": "#/components/schemas/EnvironmentToolV1"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "NewEnvironmentV1": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NewEnvironmentRevisionV1"
+          },
+          {
+            "properties": {
+              "addBaseDependencies": {
+                "description": "Required for creating a new environment",
+                "type": "boolean"
+              },
+              "description": {
+                "type": "string"
+              },
+              "duplicateFromEnvironmentId": {
+                "description": "The id of the environment to duplicate. When specifying this property, no other properties in the payload must be set.",
+                "type": "string"
+              },
+              "isCurated": {
+                "type": "boolean"
+              },
+              "isRestricted": {
+                "description": "Specifies if an environment is restricted. Only users with ClassifyEnvironments permission can set this to true",
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Environment name. Required for creating a new environment",
+                "type": "string"
+              },
+              "orgOwnerId": {
+                "description": "Sets an Organization as the Environment owner. Only used if visibility is 'Private', as 'Global' environments don't have owners.",
+                "type": "string"
+              },
+              "visibility": {
+                "$ref": "#/components/schemas/NewEnvironmentVisibilityV1"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "NewEnvironmentVisibilityV1": {
+        "description": "Environment visibility. Required for creating a new environment",
+        "enum": [
+          "global",
+          "private"
+        ],
+        "type": "string"
+      },
+      "NewJobV1": {
+        "properties": {
+          "commitId": {
+            "description": "Git commitId to start job from. Defaults to head commitId for the project.",
+            "example": "960a4c99a4cc38194cbacbcce41caa68ba5369ea",
+            "type": "string"
+          },
+          "computeCluster": {
+            "$ref": "#/components/schemas/ComputeClusterConfigV1"
+          },
+          "environmentId": {
+            "description": "Id of environment to use when creating job. Defaults to project default environment.",
+            "example": "623131507a0af0281c01a699",
+            "type": "string"
+          },
+          "environmentRevisionSpec": {
+            "$ref": "#/components/schemas/EnvironmentRevisionSpecV1"
+          },
+          "externalVolumeMountIds": {
+            "description": "Id's of external volumes to be mounted on this job.",
+            "example": [
+              "6231327c7a0af0281c01a69b",
+              "623132867a0af0281c01a69c"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "hardwareTier": {
+            "description": "Hardware tier to use for this job. Defaults to project default hardware tier.",
+            "example": "small-k8s",
+            "type": "string"
+          },
+          "mainRepoGitRef": {
+            "$ref": "#/components/schemas/GitRefV1"
+          },
+          "projectId": {
+            "description": "Id of project to create job in.",
+            "example": "623130ad7a0af0281c01a698",
+            "type": "string"
+          },
+          "runCommand": {
+            "description": "Command for job to run",
+            "example": "main.py",
+            "type": "string"
+          },
+          "snapshotDatasetsOnCompletion": {
+            "description": "Whether to snapshot datasets mounted on the Job when the Job completes.",
+            "type": "boolean"
+          },
+          "title": {
+            "description": "Name of job to start",
+            "example": "K-means clustering",
+            "type": "string"
+          }
+        },
+        "required": [
+          "projectId",
+          "runCommand"
+        ],
+        "type": "object"
+      },
+      "NewMetricValueV1": {
+        "properties": {
+          "metric": {
+            "description": "Name of the metric to log values for",
+            "type": "string"
+          },
+          "modelMonitoringId": {
+            "description": "ID of the monitored model to log metric values for",
+            "type": "string"
+          },
+          "referenceTimestamp": {
+            "description": "Timestamp to associate the metric log entry with. Timestamp should follow the RFC3339 format with timezone e.g. 2013-07-01T17:55:13-07:00",
+            "type": "string"
+          },
+          "tags": {
+            "description": "List of tags associated with the metric",
+            "items": {
+              "$ref": "#/components/schemas/MetricTagV1"
+            },
+            "type": "array"
+          },
+          "value": {
+            "description": "Value of the metric",
+            "type": "number"
+          }
+        },
+        "required": [
+          "modelMonitoringId",
+          "metric",
+          "value",
+          "referenceTimestamp"
+        ],
+        "type": "object"
+      },
+      "NewMetricValuesEnvelopeV1": {
+        "properties": {
+          "newMetricValues": {
+            "items": {
+              "$ref": "#/components/schemas/NewMetricValueV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "newMetricValues"
+        ],
+        "type": "object"
+      },
+      "NewOrganizationV1": {
+        "properties": {
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationMemberV1"
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "The name for this organization",
+            "example": "MyNewOrg",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "members"
+        ],
+        "type": "object"
+      },
+      "NewProjectGitRepositoryV1": {
+        "properties": {
+          "defaultRef": {
+            "$ref": "#/components/schemas/ProjectRepositoryReferenceV1"
+          },
+          "gitCredentialId": {
+            "description": "Id of the git creds to use for the repo. Credentials only apply for the current user, and other users will need to add their own unique creds.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Optional name of the repository in the project",
+            "type": "string"
+          },
+          "serviceProvider": {
+            "$ref": "#/components/schemas/GitServiceProviderV1"
+          },
+          "uri": {
+            "description": "URI of the repository origin",
+            "example": "https://github.com/torvalds/linux",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uri"
+        ],
+        "type": "object"
+      },
+      "NewProjectGoalV1": {
+        "properties": {
+          "assigneeId": {
+            "description": "Optional id of the user the goal will be assigned to",
+            "type": "string"
+          },
+          "description": {
+            "description": "An optional description of the goal",
+            "type": "string"
+          },
+          "stageId": {
+            "description": "Optional id of the stage the goal will be set to",
+            "type": "string"
+          },
+          "title": {
+            "description": "Title of the goal",
+            "example": "MyGoal",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "NewProjectV1": {
+        "properties": {
+          "description": {
+            "description": "Project description.",
+            "type": "string"
+          },
+          "isRestricted": {
+            "description": "Optional flag for setting a new project as restricted. ProjectClassifier permission required for use.",
+            "type": "boolean"
+          },
+          "mainRepository": {
+            "$ref": "#/components/schemas/NewProjectGitRepositoryV1"
+          },
+          "name": {
+            "description": "Name of this project. The name must be unique and cannot contain white space.",
+            "type": "string"
+          },
+          "ownerId": {
+            "description": "Optional Id of a user to own this project. Defaults to the calling user if not provided. Does not currently support creating projects owned by Organizations.",
+            "type": "string"
+          },
+          "templateDetails": {
+            "$ref": "#/components/schemas/ProjectTemplateDetailsV1"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/ProjectVisibilityV1"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "visibility"
+        ],
+        "type": "object"
+      },
+      "NewRegisteredModelReviewResponseV1": {
+        "properties": {
+          "decision": {
+            "description": "The decision of the reviewer",
+            "example": "Approved",
+            "type": "string"
+          },
+          "notes": {
+            "description": "The notes of the reviewer",
+            "example": "LGTM",
+            "type": "string"
+          }
+        },
+        "required": [
+          "decision"
+        ],
+        "type": "object"
+      },
+      "NewRegisteredModelReviewReviewersV1": {
+        "properties": {
+          "userId": {
+            "description": "The user Id of the user to be set as reviewer",
+            "example": "452f88ac21bd0c60eca085",
+            "type": "string"
+          }
+        },
+        "required": [
+          "userId"
+        ],
+        "type": "object"
+      },
+      "NewRegisteredModelReviewV1": {
+        "properties": {
+          "notes": {
+            "description": "The notes added to the review",
+            "example": "Please review this model",
+            "type": "string"
+          },
+          "reviewers": {
+            "description": "The users to be set as reviewers",
+            "items": {
+              "$ref": "#/components/schemas/NewRegisteredModelReviewReviewersV1"
+            },
+            "type": "array"
+          },
+          "targetStage": {
+            "description": "The target stage for the new review",
+            "example": "QA",
+            "type": "string"
+          }
+        },
+        "required": [
+          "targetStage",
+          "reviewers"
+        ],
+        "type": "object"
+      },
+      "NewRegisteredModelV1": {
+        "properties": {
+          "description": {
+            "description": "The description of the registered model",
+            "example": "This model predicts housing prices",
+            "type": "string"
+          },
+          "discoverable": {
+            "description": "Indicates whether this model is publicly discoverable. If true, users who are not project members will see this model in search results and can view basic model details.\n",
+            "type": "boolean"
+          },
+          "experimentRunId": {
+            "description": "The id of the experiment run to create the version from",
+            "example": "a8ea375c781d4b9c8e58469f0ad738f8",
+            "type": "string"
+          },
+          "modelName": {
+            "description": "The name of the registered model",
+            "example": "Housing Price Predictor",
+            "type": "string"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/RegisteredModelTagsV1"
+          }
+        },
+        "required": [
+          "modelName",
+          "experimentRunId",
+          "discoverable"
+        ],
+        "type": "object"
+      },
+      "NewRegisteredModelVersionV1": {
+        "properties": {
+          "artifact": {
+            "description": "The artifact of the run to create the version from",
+            "example": "LogisticRegression",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description of the registered model version",
+            "example": "Logistic regression model version 2",
+            "type": "string"
+          },
+          "experimentRunId": {
+            "description": "The id of the experiment run to create the version from",
+            "example": "a8ea375c781d4b9c8e58469f0ad738f8",
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "experimentRunId",
+          "artifact"
+        ],
+        "type": "object"
+      },
+      "NewSnapshotV1": {
+        "properties": {
+          "relativeFilePaths": {
+            "description": "List of paths to include in snapshot",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "relativeFilePaths"
+        ],
+        "type": "object"
+      },
+      "NewWorkspaceSessionV1": {
+        "properties": {
+          "externalVolumeMounts": {
+            "default": [],
+            "items": {
+              "description": "External volume mount IDs",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "externalVolumeMounts"
+        ],
+        "type": "object"
+      },
+      "OrganizationEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "org": {
+            "$ref": "#/components/schemas/OrganizationV1"
+          }
+        },
+        "required": [
+          "org",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "OrganizationMemberV1": {
+        "properties": {
+          "organizationRole": {
+            "$ref": "#/components/schemas/OrganizationRoleV1"
+          },
+          "userId": {
+            "description": "Id of the user in the org.",
+            "example": "6234c9542bc6731e3471ade8",
+            "type": "string"
+          }
+        },
+        "required": [
+          "userId",
+          "organizationRole"
+        ],
+        "type": "object"
+      },
+      "OrganizationRoleV1": {
+        "description": "Role of member in the organization.",
+        "enum": [
+          "member",
+          "admin"
+        ],
+        "type": "string"
+      },
+      "OrganizationV1": {
+        "properties": {
+          "defaultEnvironmentId": {
+            "description": "Id of the default environment used in the organization.",
+            "example": "6231327c7a0af0281c01a65f",
+            "type": "string"
+          },
+          "id": {
+            "description": "Organization identifier in the users collection.",
+            "example": "623132867a0af0281c01a69c",
+            "type": "string"
+          },
+          "members": {
+            "description": "List of the organization members.",
+            "items": {
+              "$ref": "#/components/schemas/OrganizationMemberV1"
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "Organization name.",
+            "example": "MyOrg",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "members"
+        ],
+        "type": "object"
+      },
+      "PaginatedDatasetRwEnvelopeV1": {
+        "properties": {
+          "datasets": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetRwDetailsV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          }
+        },
+        "required": [
+          "datasets",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedDatasetRwEnvelopeV2": {
+        "properties": {
+          "datasets": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetRwInfoDtoV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          }
+        },
+        "required": [
+          "datasets",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedEnvironmentEnvelopeV1": {
+        "properties": {
+          "environments": {
+            "items": {
+              "$ref": "#/components/schemas/EnvironmentV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          }
+        },
+        "required": [
+          "environments",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedGitCredentialsAccessorEnvelopeV1": {
+        "properties": {
+          "credentials": {
+            "items": {
+              "$ref": "#/components/schemas/GitCredentialsAccessorV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "credentials",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedGitRepositoriesEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          },
+          "repositories": {
+            "items": {
+              "$ref": "#/components/schemas/ProjectGitRepositoryV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "repositories",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedGoalEnvelopeV1": {
+        "properties": {
+          "goals": {
+            "items": {
+              "$ref": "#/components/schemas/LinkedGoalV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "goals",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedJobEnvelopeV1": {
+        "properties": {
+          "jobs": {
+            "items": {
+              "$ref": "#/components/schemas/JobV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          }
+        },
+        "required": [
+          "jobs",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedMetadataV1": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          {
+            "$ref": "#/components/schemas/PaginationV1"
+          }
+        ],
+        "required": [
+          "pagination",
+          "requestId",
+          "notices"
+        ]
+      },
+      "PaginatedOrganizationEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          },
+          "orgs": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "orgs",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedProjectsEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          },
+          "projects": {
+            "items": {
+              "$ref": "#/components/schemas/ProjectV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "projects",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedRegisteredModelNamesV1": {
+        "properties": {
+          "items": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          }
+        },
+        "required": [
+          "items",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedRegisteredModelVersionModelApiEnvelopeV1": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelVersionModelApiV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          }
+        },
+        "required": [
+          "items",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedRegisteredModelVersionOverviewEnvelopeV1": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelVersionOverviewV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          }
+        },
+        "required": [
+          "items",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedRegisteredModelsEnvelopeV1": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/TokenPaginatedMetadataV1"
+          }
+        },
+        "required": [
+          "items",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedRegisteredModelsForUIEnvelopeV1": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelForUIV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/TokenPaginatedMetadataV1"
+          }
+        },
+        "required": [
+          "items",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedSnapshotEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          },
+          "snapshots": {
+            "items": {
+              "$ref": "#/components/schemas/SnapshotDetailsV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "snapshots",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedUserEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          },
+          "users": {
+            "items": {
+              "$ref": "#/components/schemas/UserV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "users",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginationV1": {
+        "properties": {
+          "limit": {
+            "description": "Max number of objects returned",
+            "type": "integer"
+          },
+          "offset": {
+            "description": "Number of object skipped forward from start of objects",
+            "type": "integer"
+          },
+          "totalCount": {
+            "description": "Total number of available objects",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "offset",
+          "limit"
+        ],
+        "type": "object"
+      },
+      "PatchRegisteredModelV1": {
+        "properties": {
+          "description": {
+            "description": "The description of the registered model",
+            "example": "Logistic regression model",
+            "type": "string"
+          },
+          "discoverable": {
+            "description": "Whether this registered model is discoverable",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "ProjectCollaboratorEnvelopeV1": {
+        "properties": {
+          "collaborator": {
+            "$ref": "#/components/schemas/ProjectCollaboratorV1"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "collaborator",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "ProjectCollaboratorV1": {
+        "properties": {
+          "id": {
+            "description": "userId of collaborating user or organization",
+            "example": "662604702b7e5d347dbe7a908",
+            "type": "string"
+          },
+          "role": {
+            "description": "Collaborator's role in the project",
+            "enum": [
+              "contributor",
+              "launcherUser",
+              "resultsConsumer",
+              "projectImporter"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "role"
+        ],
+        "type": "object"
+      },
+      "ProjectCopyResultEnvelopeV1": {
+        "properties": {
+          "datasetsNotCopied": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetNotCopiedV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "project": {
+            "$ref": "#/components/schemas/ProjectV1"
+          }
+        },
+        "required": [
+          "project",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "ProjectEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "project": {
+            "$ref": "#/components/schemas/ProjectV1"
+          }
+        },
+        "required": [
+          "project",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "ProjectGitRepositoryEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "repository": {
+            "$ref": "#/components/schemas/ProjectGitRepositoryV1"
+          }
+        },
+        "required": [
+          "repository",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "ProjectGitRepositoryV1": {
+        "properties": {
+          "defaultRef": {
+            "$ref": "#/components/schemas/ProjectRepositoryReferenceV1"
+          },
+          "id": {
+            "description": "Id of the repository",
+            "example": "62604702b7e5d347dbe7a908",
+            "type": "string"
+          },
+          "name": {
+            "description": "Optional name of the repository in the project. If not provided, a name will be inferred from the URL",
+            "type": "string"
+          },
+          "serviceProvider": {
+            "$ref": "#/components/schemas/GitServiceProviderV1"
+          },
+          "uri": {
+            "description": "URI of the repository origin",
+            "example": "https://github.com/torvalds/linux",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "uri",
+          "defaultRef",
+          "serviceProvider"
+        ],
+        "type": "object"
+      },
+      "ProjectGoalEnvelopeV1": {
+        "properties": {
+          "goal": {
+            "$ref": "#/components/schemas/ProjectGoalV1"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "goal",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "ProjectGoalForUpdateV1": {
+        "properties": {
+          "isComplete": {
+            "description": "Flag indicating if the goal is complete",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "isComplete"
+        ],
+        "type": "object"
+      },
+      "ProjectGoalV1": {
+        "properties": {
+          "createdAt": {
+            "description": "Timestamp at which goal was created",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "creatorId": {
+            "description": "User id that created the goal",
+            "type": "string"
+          },
+          "description": {
+            "description": "Optional description of project goal",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique project goal id",
+            "type": "string"
+          },
+          "isComplete": {
+            "description": "Flag indicating if the goal is complete",
+            "type": "boolean"
+          },
+          "projectId": {
+            "description": "Id of project to which the goal belongs",
+            "type": "string"
+          },
+          "title": {
+            "description": "The title of project goal",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "isComplete",
+          "projectId",
+          "createdAt",
+          "creatorId"
+        ],
+        "type": "object"
+      },
+      "ProjectGoalsEnvelopeV1": {
+        "properties": {
+          "goals": {
+            "items": {
+              "$ref": "#/components/schemas/ProjectGoalV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "goals",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "ProjectRepositoryReferenceV1": {
+        "properties": {
+          "refType": {
+            "$ref": "#/components/schemas/GitReferenceTypeV1"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "refType"
+        ],
+        "type": "object"
+      },
+      "ProjectResultsSettingsEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "resultsSettings": {
+            "$ref": "#/components/schemas/ProjectResultsSettingsV1"
+          }
+        },
+        "required": [
+          "resultsSettings",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "ProjectResultsSettingsV1": {
+        "properties": {
+          "branch": {
+            "enum": [
+              "isolated",
+              "main"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "branch"
+        ],
+        "type": "object"
+      },
+      "ProjectStatusEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ProjectStatusV1"
+          }
+        },
+        "required": [
+          "status",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "ProjectStatusV1": {
+        "properties": {
+          "blockedReason": {
+            "description": "The reason the project is blocked",
+            "type": "string"
+          },
+          "completedMessage": {
+            "description": "The completed project message",
+            "type": "string"
+          },
+          "isBlocked": {
+            "description": "Whether or not the project is blocked. If true, it has precedence over the status",
+            "type": "boolean"
+          },
+          "status": {
+            "description": "The project status",
+            "enum": [
+              "active",
+              "complete"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "isBlocked"
+        ],
+        "type": "object"
+      },
+      "ProjectTemplateDetailsV1": {
+        "properties": {
+          "name": {
+            "description": "name of the template",
+            "example": "ImageNet Classifier",
+            "type": "string"
+          },
+          "templateId": {
+            "description": "id of the template",
+            "example": "templateId",
+            "type": "string"
+          },
+          "templateRevisionId": {
+            "description": "optional id of the revision of the template",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "templateId"
+        ],
+        "type": "object"
+      },
+      "ProjectV1": {
+        "properties": {
+          "collaborators": {
+            "description": "List of collaborators, if any",
+            "items": {
+              "$ref": "#/components/schemas/ProjectCollaboratorV1"
+            },
+            "type": "array"
+          },
+          "description": {
+            "description": "A description of the project",
+            "type": "string"
+          },
+          "id": {
+            "description": "Project ID",
+            "example": "626046fcb7e5d347dbe7a904",
+            "type": "string"
+          },
+          "internal tags": {
+            "description": "Optional list of strings containing internal tags of project",
+            "example": [
+              "restricted"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "mainRepository": {
+            "$ref": "#/components/schemas/ProjectGitRepositoryV1"
+          },
+          "name": {
+            "description": "Name of the project",
+            "example": "My Project",
+            "type": "string"
+          },
+          "ownerId": {
+            "description": "userId of the project owner",
+            "example": "662604702b7e5d347dbe7a908",
+            "type": "string"
+          },
+          "ownerUsername": {
+            "description": "username of the project owner",
+            "example": "steve_holt",
+            "type": "string"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/ProjectVisibilityV1"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "visibility",
+          "ownerId",
+          "ownerUsername",
+          "collaborators",
+          "internalTags"
+        ],
+        "type": "object"
+      },
+      "ProjectVisibilityV1": {
+        "description": "Project visibility",
+        "enum": [
+          "public",
+          "searchable",
+          "private"
+        ],
+        "type": "string"
+      },
+      "ProviderRepoVisibilityV1": {
+        "description": "The visibility of the code repo. Internal can only be used for Github Enterprise.",
+        "enum": [
+          "public",
+          "private",
+          "internal"
+        ],
+        "type": "string"
+      },
+      "ProxyConfigV1": {
+        "properties": {
+          "internalPath": {
+            "description": "Path to find workspace at. Used internally.",
+            "example": "/{{ownerUsername}}/{{projectName}}/{{sessionPathComponent}}/{{runId}}/{{#if pathToOpen}}tree/{{pathToOpen}}{{/if}}",
+            "type": "string"
+          },
+          "port": {
+            "description": "Port to run this tool on.",
+            "example": 8888,
+            "type": "integer"
+          },
+          "requireSubdomain": {
+            "description": "Whether workspace requires subdomains. Subdomain workspaces only work if deployment is configured to support subdomains. Defaults to false.",
+            "example": false,
+            "type": "boolean"
+          },
+          "rewrite": {
+            "description": "If url rewriting is necessary for routing. Defaults to false",
+            "example": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "internalPath",
+          "port"
+        ],
+        "type": "object"
+      },
+      "QueuedJobStatusDetailsV1": {
+        "properties": {
+          "expectedWait": {
+            "description": "Message describing estimated wait time between state changes.",
+            "example": "Now",
+            "type": "string"
+          },
+          "explanation": {
+            "description": "Message explaining the wait time",
+            "example": "Your run has been assigned to a machine",
+            "type": "string"
+          },
+          "helpText": {
+            "description": "Message informing the caller what should be done next",
+            "example": "It will start being prepared for execution momentarily",
+            "type": "string"
+          }
+        },
+        "required": [
+          "expectedWait",
+          "explanation",
+          "helpText"
+        ],
+        "type": "object"
+      },
+      "ReferenceCopyGitRepoSpecV1": {
+        "description": "Specifies the git service provider repository to use as the code repository in the new Domino project.",
+        "properties": {
+          "mainRepoUrl": {
+            "description": "The cloneable url for the git service provider repository. Must be a http(s) schema url.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "mainRepoUrl"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelForUIV1": {
+        "properties": {
+          "createdAt": {
+            "description": "When the latest version of the model was created",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "description": {
+            "description": "Description of the model",
+            "example": "Customer churn model",
+            "type": "string"
+          },
+          "discoverable": {
+            "default": false,
+            "description": "Indicates whether this model is publicly discoverable. If true, users who are not project members will see this model in search results and can view basic model details.\nThis field may be omitted when false.\n",
+            "type": "boolean"
+          },
+          "latestVersion": {
+            "description": "The latest version of the model",
+            "example": 1,
+            "type": "integer"
+          },
+          "latestVersionExperimentMetrics": {
+            "$ref": "#/components/schemas/RegisteredModelMetricsV1"
+          },
+          "latestVersionStage": {
+            "description": "The current stage of the latest version of the model",
+            "example": "Staging",
+            "type": "string"
+          },
+          "modelApiCount": {
+            "description": "The number of model APIs associated with the latest version of the model",
+            "example": 1,
+            "type": "integer"
+          },
+          "name": {
+            "description": "Name of the registered model",
+            "example": "churn-prediction",
+            "type": "string"
+          },
+          "ownerUsername": {
+            "description": "Username of the project owner",
+            "example": "martin_hito",
+            "type": "string"
+          },
+          "predictionCount": {
+            "description": "The number of predictions captured for the active versions of model APIs associated with the latest version of the model",
+            "example": 100,
+            "type": "integer"
+          },
+          "project": {
+            "$ref": "#/components/schemas/RegisteredModelProjectSummaryV1"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/RegisteredModelTagsV1"
+          },
+          "updatedAt": {
+            "description": "When the latest version of the model was updated",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "project",
+          "tags",
+          "ownerUsername",
+          "createdAt",
+          "updatedAt",
+          "modelApiCount"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelMetricsV1": {
+        "additionalProperties": {
+          "format": "double",
+          "type": "number"
+        },
+        "description": "A map of key -> value",
+        "example": {
+          "key": "foo",
+          "value": 1
+        },
+        "type": "object"
+      },
+      "RegisteredModelProjectSummaryV1": {
+        "description": "type that tracks properties of the project associated with a model",
+        "properties": {
+          "id": {
+            "description": "ID of the project housing the model",
+            "example": "62313ce67a0af0281c01a6a5",
+            "type": "string"
+          },
+          "isGitBasedProject": {
+            "description": "Whether the project is a git-based project",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Name of the project overview housing the model",
+            "example": "TO-DO",
+            "type": "string"
+          },
+          "ownerUsername": {
+            "description": "Name of the project owner",
+            "example": "TO-DO",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "ownerUsername",
+          "isGitBasedProject"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelRequestingUserAccessV1": {
+        "properties": {
+          "canEditModel": {
+            "description": "True if the requesting user can update this model",
+            "type": "boolean"
+          },
+          "canEditProjectAssets": {
+            "description": "True if the requesting user has permissions to edit other assets of the project that this model belongs to.\n",
+            "type": "boolean"
+          },
+          "canViewExperimentRuns": {
+            "description": "True if the requesting user can view experiment runs of the project that this model belongs to.\n",
+            "type": "boolean"
+          },
+          "canViewModelApis": {
+            "description": "True if the requesting user can view model apis of the project that this model belongs to.\n",
+            "type": "boolean"
+          },
+          "canViewProject": {
+            "description": "True if the requesting user can view the project overview of the project that this model belongs to.\n",
+            "type": "boolean"
+          },
+          "canViewProjectFiles": {
+            "description": "True if the requesting user can view the files of the project that this model belongs to.\n",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "canEditModel",
+          "canEditProjectAssets",
+          "canViewExperimentRuns",
+          "canViewModelApis",
+          "canViewProject",
+          "canViewProjectFiles"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelReviewSummaryV1": {
+        "properties": {
+          "modelReviewId": {
+            "description": "The id of the model review",
+            "type": "string"
+          },
+          "notes": {
+            "description": "The notes of the review",
+            "example": "Please review this model",
+            "type": "string"
+          },
+          "reviewerResponses": {
+            "items": {
+              "properties": {
+                "decision": {
+                  "description": "The response of the reviewer",
+                  "example": "Approved",
+                  "type": "string"
+                },
+                "reviewer": {
+                  "$ref": "#/components/schemas/RegisteredModelReviewUserInfoV1"
+                }
+              },
+              "required": [
+                "reviewer"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "description": "The status of the model review",
+            "type": "string"
+          },
+          "targetStage": {
+            "description": "The target stage of the model review",
+            "type": "string"
+          }
+        },
+        "required": [
+          "modelReviewId",
+          "targetStage",
+          "notes",
+          "status",
+          "reviewerResponses"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelReviewUserInfoV1": {
+        "properties": {
+          "firstName": {
+            "description": "The first name of the model review user",
+            "example": "Tuanathon",
+            "type": "string"
+          },
+          "id": {
+            "description": "The id of the model review user",
+            "example": "452f88ac21bd0c60eca085",
+            "type": "string"
+          },
+          "lastName": {
+            "description": "The last name of the model review user",
+            "example": "Nguyen",
+            "type": "string"
+          },
+          "username": {
+            "description": "The username of the model review user",
+            "example": "ddl-tnguyen",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "firstName",
+          "lastName"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelStageEnvelopeV1": {
+        "properties": {
+          "items": {
+            "description": "The Registered Model stages",
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelStageV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "items",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelStageV1": {
+        "properties": {
+          "label": {
+            "description": "The label of the model stage",
+            "example": "QA",
+            "type": "string"
+          }
+        },
+        "required": [
+          "label"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelTagsV1": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "A map of key -> value",
+        "example": {
+          "key": "foo",
+          "value": "bar"
+        },
+        "type": "object"
+      },
+      "RegisteredModelV1": {
+        "properties": {
+          "createdAt": {
+            "description": "When the latest version of the model was created",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "description": {
+            "description": "Description of the model",
+            "example": "Customer churn model",
+            "type": "string"
+          },
+          "discoverable": {
+            "default": false,
+            "description": "Indicates whether this model is publicly discoverable. If true, users who are not project members will see this model in search results and can view basic model details.\nThis field may be omitted when false.\n",
+            "type": "boolean"
+          },
+          "latestVersion": {
+            "description": "The latest version of the model",
+            "example": 1,
+            "type": "integer"
+          },
+          "name": {
+            "description": "Name of the registered model",
+            "example": "churn-prediction",
+            "type": "string"
+          },
+          "ownerUsername": {
+            "description": "Username of the model's creator",
+            "example": "martin_hito",
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/RegisteredModelProjectSummaryV1"
+          },
+          "requestingUserAccess": {
+            "$ref": "#/components/schemas/RegisteredModelRequestingUserAccessV1",
+            "description": "Describes the operations that the requesting user has permission to do with this model."
+          },
+          "tags": {
+            "$ref": "#/components/schemas/RegisteredModelTagsV1"
+          },
+          "updatedAt": {
+            "description": "When the latest version of the model was updated",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "project",
+          "tags",
+          "ownerUsername",
+          "createdAt",
+          "updatedAt",
+          "requestingUserAccess"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionCustomStageResponseV1": {
+        "properties": {
+          "label": {
+            "description": "The label of the model stage",
+            "example": "QA",
+            "type": "string"
+          }
+        },
+        "required": [
+          "label"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionCustomStageV1": {
+        "properties": {
+          "label": {
+            "description": "The custom stage of a registered model version for a project",
+            "example": "Pre-Production",
+            "type": "string"
+          }
+        },
+        "required": [
+          "label"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionDataSourceDetailsV1": {
+        "properties": {
+          "dataSourceType": {
+            "description": "The dataSourceType of the datasource",
+            "type": "string"
+          },
+          "id": {
+            "description": "The id of the datasource",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the datasource",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "id",
+          "dataSourceType"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionDatasetDetailsV1": {
+        "properties": {
+          "id": {
+            "description": "The id of the dataset",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the dataset",
+            "type": "string"
+          },
+          "snapshotId": {
+            "description": "The snapshotId of the dataset",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "id",
+          "snapshotId"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionDetailsV1": {
+        "properties": {
+          "createdAt": {
+            "description": "When the latest version of the model was created",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "currentStage": {
+            "description": "The current stage of the model version",
+            "example": "Staging",
+            "type": "string"
+          },
+          "experimentRunId": {
+            "description": "The name of experiment run linked to the model version",
+            "example": "db79712b47084c27a463a188bf901943",
+            "type": "string"
+          },
+          "modelName": {
+            "description": "Name of the registered model",
+            "example": "churn-prediction",
+            "type": "string"
+          },
+          "modelVersion": {
+            "description": "The latest version of the model",
+            "example": 4,
+            "type": "integer"
+          },
+          "modelVersionDescription": {
+            "description": "Description of the model version",
+            "example": "Customer churn model V1",
+            "type": "string"
+          },
+          "ownerUsername": {
+            "description": "username of the project owner",
+            "example": "martin_hito",
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/RegisteredModelProjectSummaryV1"
+          },
+          "reviewSummary": {
+            "$ref": "#/components/schemas/RegisteredModelReviewSummaryV1"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/RegisteredModelTagsV1"
+          },
+          "updatedAt": {
+            "description": "When the latest version of the model was updated",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "versionUiDetails": {
+            "$ref": "#/components/schemas/RegisteredModelVersionUiDetailsV1"
+          }
+        },
+        "required": [
+          "modelName",
+          "modelVersion",
+          "modelVersionDescription",
+          "experimentRunId",
+          "currentStage",
+          "project",
+          "versionUiDetails",
+          "tags",
+          "ownerUsername",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionExperimentRunInfoV1": {
+        "properties": {
+          "metrics": {
+            "description": "Run metrics.",
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelVersionExperimentRunMetricV1"
+            },
+            "type": "array"
+          },
+          "params": {
+            "description": "Run parameters.",
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelVersionExperimentRunParamV1"
+            },
+            "type": "array"
+          },
+          "runUrl": {
+            "description": "The snapshotId of the dataset",
+            "type": "string"
+          }
+        },
+        "required": [
+          "metrics",
+          "params",
+          "runUrl"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionExperimentRunMetricV1": {
+        "properties": {
+          "key": {
+            "description": "Key identifying this metric.",
+            "type": "string"
+          },
+          "timestamp": {
+            "description": "The timestamp at which this metric was recorded.",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "value": {
+            "description": "Value associated with this metric.",
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "key",
+          "value",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionExperimentRunParamV1": {
+        "properties": {
+          "key": {
+            "description": "Key identifying this param.",
+            "type": "string"
+          },
+          "value": {
+            "description": "Value associated with this param.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionModelApiV1": {
+        "properties": {
+          "activeModelVersionId": {
+            "description": "The id of the Model API",
+            "example": "6452f88ac21bd0c60eca087",
+            "type": "string"
+          },
+          "activeVersionNumber": {
+            "description": "The active version number of the Model API",
+            "example": 2,
+            "type": "integer"
+          },
+          "activeVersionStatus": {
+            "description": "The status of the Model API",
+            "example": "Running",
+            "type": "string"
+          },
+          "description": {
+            "description": "Description of the model",
+            "example": "Customer churn model",
+            "type": "string"
+          },
+          "id": {
+            "description": "ID of the Model API",
+            "example": "6452f88ac21bd0c60eca085",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the Model API",
+            "example": "Test Model API",
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/RegisteredModelProjectSummaryV1"
+          },
+          "updatedAt": {
+            "description": "When the latest version of the model was updated",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "project",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionOverviewV1": {
+        "properties": {
+          "createdAt": {
+            "description": "When the latest version of the model was created",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "experimentRunId": {
+            "description": "The name of experiment run linked to the model version",
+            "example": "db79712b47084c27a463a188bf901943",
+            "type": "string"
+          },
+          "modelName": {
+            "description": "Name of the registered model",
+            "example": "churn-prediction",
+            "type": "string"
+          },
+          "modelVersion": {
+            "description": "The latest version of the model",
+            "example": 4,
+            "type": "integer"
+          },
+          "ownerUsername": {
+            "description": "username of the project owner",
+            "example": "martin_hito",
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/RegisteredModelProjectSummaryV1"
+          },
+          "updatedAt": {
+            "description": "When the latest version of the model was updated",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "modelName",
+          "modelVersion",
+          "experimentRunId",
+          "project",
+          "ownerUsername",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionReviewStageResponseV1": {
+        "properties": {
+          "label": {
+            "description": "The label of the model stage valid for starting a model review",
+            "example": "QA",
+            "type": "string"
+          }
+        },
+        "required": [
+          "label"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionReviewStagesResponseV1": {
+        "properties": {
+          "items": {
+            "description": "The registered model version stages valid for starting a model review",
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelVersionReviewStageResponseV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "items",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionStageValidationV1": {
+        "properties": {
+          "stage": {
+            "description": "The stage to validate the transition for",
+            "example": "QA",
+            "type": "string"
+          }
+        },
+        "required": [
+          "stage"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionStagesResponseV1": {
+        "properties": {
+          "items": {
+            "description": "The Registered Model Version stages for a project",
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelVersionCustomStageResponseV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "items",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionStagesV1": {
+        "properties": {
+          "stages": {
+            "description": "The Registered Model Version stages for a project",
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelVersionCustomStageV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "stages"
+        ],
+        "type": "object"
+      },
+      "RegisteredModelVersionUiDetailsV1": {
+        "properties": {
+          "experimentRunInfo": {
+            "$ref": "#/components/schemas/RegisteredModelVersionExperimentRunInfoV1"
+          },
+          "modelVersionDataSources": {
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelVersionDataSourceDetailsV1"
+            },
+            "type": "array"
+          },
+          "modelVersionDatasets": {
+            "items": {
+              "$ref": "#/components/schemas/RegisteredModelVersionDatasetDetailsV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "experimentRunInfo",
+          "modelVersionDataSources",
+          "modelVersionDatasets"
+        ],
+        "type": "object"
+      },
+      "SharedDatasetRwEntryV1": {
+        "description": "An object describing the shared datasets imported into a project",
+        "properties": {
+          "projectId": {
+            "description": "Id of the project being described.",
+            "example": "62313ce67a0af0281c01a6a5",
+            "type": "string"
+          },
+          "sharedDatasetIds": {
+            "description": "List of dataset ids shared with this project",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "projectId",
+          "sharedDatasetIds"
+        ],
+        "type": "object"
+      },
+      "SharedDatasetsEnvelopeV1": {
+        "properties": {
+          "dataset": {
+            "$ref": "#/components/schemas/SharedDatasetRwEntryV1"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "dataset",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "SnapshotDetailsV1": {
+        "properties": {
+          "createdAt": {
+            "description": "When the snapshot was created",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "creatorId": {
+            "description": "ID of the user who created this snapshot",
+            "type": "string"
+          },
+          "datasetId": {
+            "description": "ID of the dataset this snapshot belongs to",
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "description": "ID of this snapshot",
+            "type": "string"
+          },
+          "lastMounted": {
+            "description": "When the snapshot was last mounted",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "active",
+              "markForDeletion",
+              "deletionInProgress",
+              "deleted",
+              "pending",
+              "failed",
+              "copying"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "datasetId",
+          "createdAt",
+          "status"
+        ],
+        "type": "object"
+      },
+      "SnapshotEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "snapshot": {
+            "$ref": "#/components/schemas/SnapshotDetailsV1"
+          }
+        },
+        "required": [
+          "snapshot",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "StageTimesV1": {
+        "properties": {
+          "completedTime": {
+            "description": "When the job completed",
+            "example": "2022-03-12T02:16:43.127Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "startTime": {
+            "description": "When the job started",
+            "example": "2022-03-12T02:15:44.848Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "submissionTime": {
+            "description": "When the start job request was submitted.",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "submissionTime"
+        ],
+        "type": "object"
+      },
+      "StreamedResponseDTO": {
+        "description": "An internal DTO to stream responses. Should not be referenced by public OAS files directly.",
+        "properties": {
+          "contentType": {
+            "type": "string"
+          },
+          "extraHeaders": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "size": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "source": {
+            "format": "binary",
+            "type": "string",
+            "x-domino-binary-stream": true
+          }
+        },
+        "required": [
+          "source",
+          "size",
+          "extraHeaders"
+        ],
+        "type": "object",
+        "x-domino-binary-stream": true
+      },
+      "TagEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "tag": {
+            "$ref": "#/components/schemas/TagV1"
+          }
+        },
+        "required": [
+          "tag",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "TagToAddV1": {
+        "properties": {
+          "projectId": {
+            "description": "Id of project the resource belongs to.",
+            "example": "62313ce67a0af0281c01a6a5",
+            "type": "string"
+          },
+          "tagName": {
+            "description": "Name of tag to add to a job.",
+            "example": "MyTag",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tagName",
+          "projectId"
+        ],
+        "type": "object"
+      },
+      "TagV1": {
+        "properties": {
+          "createdAt": {
+            "description": "When the tag was created.",
+            "example": "2022-03-15T21:48:36.586Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "creatorId": {
+            "description": "Id of the user who created the tag.",
+            "example": "6231342b7a0af0281c01a69e",
+            "type": "string"
+          },
+          "id": {
+            "description": "Id of the tag.",
+            "example": "623133e87a0af0281c01a69d",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the tag.",
+            "example": "KMeansTest",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "creatorId",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "TargetRangeV1": {
+        "properties": {
+          "condition": {
+            "description": "Condition to evaluate metric value against upperLimit/lowerLimit",
+            "enum": [
+              "lessThan",
+              "lessThanEqual",
+              "greaterThan",
+              "greaterThanEqual",
+              "between"
+            ],
+            "type": "string"
+          },
+          "lowerLimit": {
+            "description": "Lower limit in the target range for a metric; lowerLimit, upperLimit, or both must be provided",
+            "type": "number"
+          },
+          "upperLimit": {
+            "description": "Upper limit in the target range for a metric; lowerLimit, upperLimit, or both must be provided",
+            "type": "number"
+          }
+        },
+        "required": [
+          "condition"
+        ],
+        "type": "object"
+      },
+      "TokenPaginatedMetadataV1": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          {
+            "$ref": "#/components/schemas/TokenPaginationV1"
+          }
+        ],
+        "required": [
+          "pagination",
+          "requestId",
+          "notices"
+        ]
+      },
+      "TokenPaginationV1": {
+        "properties": {
+          "nextPageToken": {
+            "description": "Pagination token to request the next page of objects",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "UpdateEnvironmentRevisionV1": {
+        "properties": {
+          "isRestricted": {
+            "description": "Boolean determining if revision is restricted",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "isRestricted"
+        ],
+        "type": "object"
+      },
+      "UpdatedRegisteredModelReviewV1": {
+        "properties": {
+          "notes": {
+            "description": "The notes added to the review",
+            "example": "Updating list of reviewers for this model review",
+            "type": "string"
+          },
+          "reviewers": {
+            "description": "The users to be set as reviewers",
+            "items": {
+              "$ref": "#/components/schemas/NewRegisteredModelReviewReviewersV1"
+            },
+            "type": "array"
+          },
+          "status": {
+            "description": "The status of the review",
+            "example": "Canceled",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "UpdatedRegisteredModelVersionV1": {
+        "properties": {
+          "currentStage": {
+            "description": "The current stage of the model version",
+            "example": "Staging",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "UserEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "user": {
+            "$ref": "#/components/schemas/UserV1"
+          }
+        },
+        "required": [
+          "user",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "UserV1": {
+        "properties": {
+          "avatarUrl": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "phoneNumber": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "firstName",
+          "lastName",
+          "fullName",
+          "userName",
+          "avatarUrl"
+        ],
+        "type": "object"
+      },
+      "WorkspaceSessionCreatedEnvelopeV1": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          },
+          "workspaceSession": {
+            "$ref": "#/components/schemas/WorkspaceSessionCreatedV1"
+          }
+        },
+        "required": [
+          "workspaceSession",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "WorkspaceSessionCreatedV1": {
+        "properties": {
+          "executionId": {
+            "description": "ID of the underlying execution serving the workspace session.",
+            "type": "string"
+          },
+          "id": {
+            "description": "ID of the newly created workspace session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "executionId"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "BearerAuthentication": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey"
+      },
+      "DominoApiKey": {
+        "in": "header",
+        "name": "X-Domino-Api-Key",
+        "type": "apiKey"
+      }
+    }
+  },
+  "info": {
+    "description": "Domino Public API Endpoints",
+    "title": "Domino Public API",
+    "version": "5.9.1"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/api/cost/v1/allocation": {
+      "get": {
+        "description": "Retrieve cost allocation",
+        "operationId": "getCostAllocation",
+        "parameters": [
+          {
+            "description": "Duration of time over which to query. Accepts words like today, week, month, yesterday, lastweek, lastmonth; durations like 30m, 12h, 7d, or time like 2021-03-10T00:00:00Z,2021-03-11T00:00:00Z",
+            "in": "query",
+            "name": "window",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Aggregate the cost allocation. Accepts kubecost aggregates cluster, namespace, pod, deployment, service, daemonset, statefulset, job, cronjob, replicaset, node, container, pv, pvc, storageclass, cluster",
+            "in": "query",
+            "name": "aggregate",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start time of the query. Accepts RFC3339 format, must be inside the window",
+            "in": "query",
+            "name": "start",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "End time of the query. Accepts RFC3339 format, must be inside the window",
+            "in": "query",
+            "name": "end",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "If the result will be accumulated. Default is false. If true, the result will be accumulated from the start time to the end time.",
+            "in": "query",
+            "name": "accumulate",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Filter the result by the kubecost filter like cluster, namespace, pod, deployment, service, daemonset, statefulset, job, cronjob, replicaset, node, container, pv, pvc, storageclass, cluster.",
+            "in": "query",
+            "name": "filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "if the idle cost will be shared",
+            "in": "query",
+            "name": "shareIdle",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "list of namespaces to share the costs",
+            "in": "query",
+            "name": "shareNamespaces",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Determines how to split shared costs among non-idle, unshared allocations.",
+            "in": "query",
+            "name": "shareSplit",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The cost to share",
+            "in": "query",
+            "name": "shareCost",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The label to share the cost",
+            "in": "query",
+            "name": "shareLabels",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "If the cost will be reconciled",
+            "in": "query",
+            "name": "reconcile",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "If the tenancy costs will be shared",
+            "in": "query",
+            "name": "shareTenancyCosts",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "If the idle cost will be calculated",
+            "in": "query",
+            "name": "idle",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "If the external cost will be calculated",
+            "in": "query",
+            "name": "external",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CostAllocationEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "Get the cost allocation over a time window",
+        "tags": [
+          "Cost"
+        ]
+      }
+    },
+    "/api/cost/v1/asset": {
+      "get": {
+        "description": "Retrieve asset cost",
+        "operationId": "getCostAssets",
+        "parameters": [
+          {
+            "description": "Duration of time over which to query. Accepts words like today, week, month, yesterday, lastweek, lastmonth; durations like 30m, 12h, 7d, or time like 2021-03-10T00:00:00Z,2021-03-11T00:00:00Z",
+            "in": "query",
+            "name": "window",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Aggregate the cost allocation. Accepts kubecost aggregates cluster, namespace, pod, deployment, service, daemonset, statefulset, job, cronjob, replicaset, node, container, pv, pvc, storageclass, cluster",
+            "in": "query",
+            "name": "aggregate",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start time of the query. Accepts RFC3339 format, must be inside the window",
+            "in": "query",
+            "name": "start",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "End time of the query. Accepts RFC3339 format, must be inside the window",
+            "in": "query",
+            "name": "end",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "If the result will be accumulated. Default is false. If true, the result will be accumulated from the start time to the end time.",
+            "in": "query",
+            "name": "accumulate",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Filter the result by the kubecost filter like cluster, namespace, pod, deployment, service, daemonset, statefulset",
+            "in": "query",
+            "name": "filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CostAssetsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "Get the asset cost over a time window",
+        "tags": [
+          "Cost"
+        ]
+      }
+    },
+    "/api/datasetrw/v1/datasets": {
+      "get": {
+        "description": "Deprecated: Use GetDatasetsV2. Get Datasets that a user has access to",
+        "operationId": "getDatasets",
+        "parameters": [
+          {
+            "description": "Project ID filter",
+            "in": "query",
+            "name": "projectId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "How many Datasets from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of Datasets to fetch. Defaults to 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedDatasetRwEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Deprecated - Get datasets accessible to user",
+        "tags": [
+          "DatasetRw"
+        ]
+      },
+      "post": {
+        "description": "Create a new Dataset. Requires access to the project the dataset will originate from",
+        "operationId": "createDataset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewDatasetRwV1"
+              }
+            }
+          },
+          "description": "Dataset to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRwEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a dataset",
+        "tags": [
+          "DatasetRw"
+        ]
+      }
+    },
+    "/api/datasetrw/v1/datasets/{datasetId}": {
+      "delete": {
+        "description": "Delete a dataset. Requires PermanentDelete access to the dataset",
+        "operationId": "deleteDataset",
+        "parameters": [
+          {
+            "description": "ID of dataset to remove from project",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRwEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "Delete Dataset",
+        "tags": [
+          "DatasetRw"
+        ]
+      },
+      "get": {
+        "description": "Get Dataset by ID. Requires List access to the dataset",
+        "operationId": "getDataset",
+        "parameters": [
+          {
+            "description": "ID of dataset to retrieve",
+            "example": "62604702b7e5d347dbe7a909",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRwEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get dataset by ID",
+        "tags": [
+          "DatasetRw"
+        ]
+      },
+      "patch": {
+        "description": "Update Dataset name or description. Requires Update access to the dataset",
+        "operationId": "updateDataset",
+        "parameters": [
+          {
+            "description": "ID of dataset to update",
+            "example": "62604702b7e5d347dbe7a909",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetRwMetadataV1"
+              }
+            }
+          },
+          "description": "Fields to update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRwEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update dataset metadata",
+        "tags": [
+          "DatasetRw"
+        ]
+      }
+    },
+    "/api/datasetrw/v1/datasets/{datasetId}/grants": {
+      "delete": {
+        "description": "Remove a grant from a dataset's existing sequence of grants. Requires EditSecurity access to the dataset",
+        "operationId": "removeDatasetGrant",
+        "parameters": [
+          {
+            "description": "ID of dataset to remove the grant from",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetRwGrantV1"
+              }
+            }
+          },
+          "description": "Grant to remove",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRwGrantEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Remove a grant from a dataset's existing sequence of grants",
+        "tags": [
+          "DatasetRw"
+        ]
+      },
+      "get": {
+        "description": "Get Dataset grants by ID. Requires List access to the dataset",
+        "operationId": "getDatasetGrants",
+        "parameters": [
+          {
+            "description": "ID of dataset to get grants for",
+            "example": "62604702b7e5d347dbe7a909",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRwGrantDetailsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get dataset grants by ID",
+        "tags": [
+          "DatasetRw"
+        ]
+      },
+      "post": {
+        "description": "Add a grant to a dataset's existing sequence of grants. Requires EditSecurity access to the dataset.",
+        "operationId": "addDatasetGrant",
+        "parameters": [
+          {
+            "description": "ID of dataset to add a grant to",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetRwGrantV1"
+              }
+            }
+          },
+          "description": "Grant to add",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRwGrantEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Add a grant to a dataset's existing sequence of grants",
+        "tags": [
+          "DatasetRw"
+        ]
+      }
+    },
+    "/api/datasetrw/v1/datasets/{datasetId}/snapshots": {
+      "get": {
+        "description": "Get Snapshots belonging to a dataset. Requires List access to the dataset",
+        "operationId": "getDatasetSnapshots",
+        "parameters": [
+          {
+            "description": "ID of dataset to retrieve snapshots for",
+            "example": "62604702b7e5d347dbe7a909",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "How many Snapshots from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of Snapshots to fetch. Defaults to 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedSnapshotEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get snapshots belonging to dataset",
+        "tags": [
+          "DatasetRw"
+        ]
+      },
+      "post": {
+        "description": "Create a new Snapshot in a dataset. Requires Read access to the dataset and project access",
+        "operationId": "createSnapshot",
+        "parameters": [
+          {
+            "description": "Dataset ID",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewSnapshotV1"
+              }
+            }
+          },
+          "description": "Snapshot to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a snapshot",
+        "tags": [
+          "DatasetRw"
+        ]
+      }
+    },
+    "/api/datasetrw/v1/datasets/{datasetId}/tags": {
+      "post": {
+        "description": "Tag a snapshot in this Dataset with the given tagName. Requires Update access to the dataset",
+        "operationId": "addDatasetTag",
+        "parameters": [
+          {
+            "description": "Dataset ID",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetRwTagToAddV1"
+              }
+            }
+          },
+          "description": "Tag name and snapshot ID to apply it to",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRwEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Tag a snapshot in this Dataset",
+        "tags": [
+          "DatasetRw"
+        ]
+      }
+    },
+    "/api/datasetrw/v1/datasets/{datasetId}/tags/{tagName}": {
+      "delete": {
+        "description": "Remove a Tag from a dataset. Requires Update access to the dataset",
+        "operationId": "removeDatasetTag",
+        "parameters": [
+          {
+            "description": "Dataset ID",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of tag to delete",
+            "in": "path",
+            "name": "tagName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRwEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Remove a tag from a Dataset",
+        "tags": [
+          "DatasetRw"
+        ]
+      }
+    },
+    "/api/datasetrw/v1/snapshots/{snapshotId}": {
+      "get": {
+        "description": "Fetch a snapshot by ID. Requires List access to the dataset",
+        "operationId": "getSnapshot",
+        "parameters": [
+          {
+            "description": "Snapshot ID",
+            "example": "62604702b7e5d347dbe7a909",
+            "in": "path",
+            "name": "snapshotId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get snapshot",
+        "tags": [
+          "DatasetRw"
+        ]
+      }
+    },
+    "/api/datasetrw/v2/datasets": {
+      "get": {
+        "description": "Get Datasets that a user has access to based on dataset permissions and input filters",
+        "operationId": "getDatasetsV2",
+        "parameters": [
+          {
+            "description": "Filter for minimum dataset permission the principal needs to have in returned datasets.",
+            "in": "query",
+            "name": "minimumPermission",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetRwPermissionV1"
+            }
+          },
+          {
+            "description": "ProjectIds of datasets to exclude from result.",
+            "in": "query",
+            "name": "projectIdsToExclude",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "ProjectIds to get the datasets from. Should not be passed in if projectIdsToExclude is and vice versa.",
+            "in": "query",
+            "name": "projectIdsToInclude",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Boolean to determine whether or not to return project-info in return objects.",
+            "in": "query",
+            "name": "includeProjectInfo",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "How many Datasets from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of Datasets to fetch. Defaults to 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedDatasetRwEnvelopeV2"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get datasets the user has access to",
+        "tags": [
+          "DatasetRw"
+        ]
+      }
+    },
+    "/api/datasource/v1/audit": {
+      "get": {
+        "description": "Gets data source audit data given filter input parameters",
+        "operationId": "getDataSourceAuditData",
+        "parameters": [
+          {
+            "description": "Datasource IDs to query audit data for",
+            "in": "query",
+            "name": "dataSourceIds",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Datasource names to query audit data for",
+            "in": "query",
+            "name": "dataSourceNames",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "events to query - AccessDataSource, CreateDataSource, DataSourceAssociatedToProject, DataSourceDissociatedFromProject, DataSourceChangeOfOwnership, DataSourceChangeOfPermissions, DeleteDataSource",
+            "in": "query",
+            "name": "eventKinds",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Start time (iso8601)",
+            "in": "query",
+            "name": "startTime",
+            "required": false,
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "End time (iso8601)",
+            "in": "query",
+            "name": "endTime",
+            "required": false,
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DataSourceAuditDataV1"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get DataSource Audit Data",
+        "tags": [
+          "DataSource"
+        ]
+      }
+    },
+    "/api/environments/beta/environments": {
+      "get": {
+        "description": "Get environments that a user can see. Required permissions: `None`. *Note:* This is a beta endpoint with known limitations.",
+        "operationId": "getEnvironments",
+        "parameters": [
+          {
+            "description": "How many Environments from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of Environments to fetch. Defaults to 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedEnvironmentEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get Environments visible to a user",
+        "tags": [
+          "Environments"
+        ]
+      },
+      "post": {
+        "description": "Create an environment. Required permissions: `CreateEnvironment, EditEnvironment, UseFileStorage`. *Note:* This is a beta endpoint with known limitations.",
+        "operationId": "createEnvironment",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewEnvironmentV1"
+              }
+            }
+          },
+          "description": "Environment to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnvironmentEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create an environment",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
+    "/api/environments/beta/environments/{environmentId}/revisions": {
+      "post": {
+        "description": "Create a revision of an environment. Required permissions: `ManageEnvironments, EditEnvironment, UseFileStorage`. *Note:* This is a beta endpoint with known limitations.",
+        "operationId": "createEnvironmentRevision",
+        "parameters": [
+          {
+            "description": "Id of environment to create revision of",
+            "in": "path",
+            "name": "environmentId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewEnvironmentRevisionV1"
+              }
+            }
+          },
+          "description": "Environment revision to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnvironmentRevisionEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a Revision of an Environment",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
+    "/api/environments/beta/environments/{environmentId}/revisions/{revisionId}": {
+      "patch": {
+        "description": "Update a revision of an environment to mark if isRestricted. Required permissions: `ClassifyEnvironments`. *Note:* This is a beta endpoint with known limitations.",
+        "operationId": "updateEnvironmentRevisionIsRestricted",
+        "parameters": [
+          {
+            "description": "Id of environment to mark restricted revision",
+            "in": "path",
+            "name": "environmentId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of environment revision to mark is restricted",
+            "in": "path",
+            "name": "revisionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateEnvironmentRevisionV1"
+              }
+            }
+          },
+          "description": "Body of isRestricted",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnvironmentRevisionUpdateEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update the restricted revision of an environment",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
+    "/api/environments/v1/environments/{environmentId}": {
+      "delete": {
+        "description": "Archive an Environment, removing it from the list of visible environments. Required permissions: `ManageEnvironments, EditEnvironment`",
+        "operationId": "archiveEnvironment",
+        "parameters": [
+          {
+            "description": "Id of environment to archive",
+            "in": "path",
+            "name": "environmentId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnvironmentEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Archive an environment",
+        "tags": [
+          "Environments"
+        ]
+      },
+      "get": {
+        "description": "Get an Environment by its Id. Required permissions: `ViewEnvironment`",
+        "operationId": "getEnvironment",
+        "parameters": [
+          {
+            "description": "Id of environment to retrieve",
+            "in": "path",
+            "name": "environmentId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnvironmentEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get an environment",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
+    "/api/jobs/beta/jobs": {
+      "get": {
+        "description": "Retrieve all Jobs that belong to a project. Required permissions: `ViewJobs.` *Note:* This is a beta endpoint with known limitations.",
+        "operationId": "getJobs",
+        "parameters": [
+          {
+            "description": "Id of project to retrieve Jobs for",
+            "example": "622a6944dde1a920fcccff0d",
+            "in": "query",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of jobs from the start to skip. Defaults to 0.",
+            "example": 2,
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Total number of Jobs to retrieve. Defaults to 10.",
+            "example": 25,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort Jobs by. Defaults to \"number\".",
+            "in": "query",
+            "name": "sortBy",
+            "schema": {
+              "enum": [
+                "number",
+                "title",
+                "command",
+                "startedTime",
+                "duration",
+                "status",
+                "user",
+                "commentCount",
+                "dominoStatsField"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Field in domino stats to sort by. Only used if sortBy = dominoStatsField.",
+            "example": "r-squared",
+            "in": "query",
+            "name": "dominoStatsSortFieldName",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Whether to sort ascending or descending. Defaults to to False.",
+            "example": true,
+            "in": "query",
+            "name": "ascending",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Whether to include archived Jobs in results. Defaults to false.",
+            "example": true,
+            "in": "query",
+            "name": "showArchived",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Status of Jobs to fetch. Defaults to \"all\".",
+            "in": "query",
+            "name": "statusFilter",
+            "schema": {
+              "enum": [
+                "all",
+                "queued",
+                "running",
+                "completed",
+                "archived",
+                "active"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Tag to filter by. Must match tag name exactly.",
+            "example": "MyTag",
+            "in": "query",
+            "name": "tagFilter",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedJobEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get Jobs for a project",
+        "tags": [
+          "Jobs"
+        ]
+      }
+    },
+    "/api/jobs/beta/jobs/{jobId}": {
+      "get": {
+        "description": "Retrieve a Job's details by its Id. Required permissions: `ViewJobs`. *Note:* This is a beta endpoint with known limitations.",
+        "operationId": "getJobDetails",
+        "parameters": [
+          {
+            "description": "Id of Job to retrieve details for",
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get Job details",
+        "tags": [
+          "Jobs"
+        ]
+      }
+    },
+    "/api/jobs/beta/jobs/{jobId}/logs": {
+      "get": {
+        "description": "Retrieve the logs for the Job with the specified Id. Required permissions: `ViewJobs`. *Note:* This is a beta endpoint with known limitations.",
+        "operationId": "getJobLogs",
+        "parameters": [
+          {
+            "description": "Id of job to get logs for",
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Type of log to retrieve. Case insensitive.",
+            "in": "query",
+            "name": "logType",
+            "required": false,
+            "schema": {
+              "enum": [
+                "stdOut",
+                "stdErr",
+                "prepareOutput",
+                "complete"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max number of log lines to fetch. Will not retrieve over 10000 log lines at a time.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The epoch time in nanoseconds to start fetching from",
+            "in": "query",
+            "name": "latestTimeNano",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get logs for a Job",
+        "tags": [
+          "Jobs"
+        ]
+      }
+    },
+    "/api/jobs/v1/goals": {
+      "get": {
+        "description": "Retrieve goals for a Job with the specified Id. Required permissions: `ViewJobs`",
+        "operationId": "getLinkedGoalsForJob",
+        "parameters": [
+          {
+            "description": "Id of job to link to goal",
+            "in": "query",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedGoalEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get linked goals for a job",
+        "tags": [
+          "Jobs"
+        ]
+      },
+      "post": {
+        "description": "Link the Goal with the specified Id to a Job. Required permissions: `ViewJobs, Edit`",
+        "operationId": "linkJobToGoal",
+        "parameters": [
+          {
+            "description": "Id of job to link to goal",
+            "in": "query",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GoalToLinkV1"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoalEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Link a goal to a job",
+        "tags": [
+          "Jobs"
+        ]
+      }
+    },
+    "/api/jobs/v1/goals/{goalId}": {
+      "delete": {
+        "description": "Unlink the Goal with the specified Id from a Job. Required permissions: `ViewJobs, Edit`",
+        "operationId": "unlinkJobFromGoal",
+        "parameters": [
+          {
+            "description": "Id of goal to remove",
+            "in": "path",
+            "name": "goalId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of job to remove goal from",
+            "in": "query",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of project for the goal",
+            "in": "query",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Unlink goal from job",
+        "tags": [
+          "Jobs"
+        ]
+      }
+    },
+    "/api/jobs/v1/jobs": {
+      "post": {
+        "description": "Start a new Job. Required permissions: `StartJob, UseGlobalCompute`",
+        "operationId": "startJob",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewJobV1"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Start a Job",
+        "tags": [
+          "Jobs"
+        ]
+      }
+    },
+    "/api/jobs/v1/jobs/{jobId}/tags": {
+      "post": {
+        "description": "Add a Tag to the Job with the specified Id. Required permissions: `ViewJobs`",
+        "operationId": "addJobTag",
+        "parameters": [
+          {
+            "description": "Id of job to add tag to",
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagToAddV1"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Add a tag to a Job",
+        "tags": [
+          "Jobs"
+        ]
+      }
+    },
+    "/api/jobs/v1/jobs/{jobId}/tags/{tagId}": {
+      "delete": {
+        "description": "Remove a Tag from the Job with the specified Id. Required permissions: `ViewJobs`",
+        "operationId": "removeJobTag",
+        "parameters": [
+          {
+            "description": "Id of job to remove tag from",
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of tag to remove",
+            "in": "path",
+            "name": "tagId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of project that tag belongs to",
+            "in": "query",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Remove a tag from a Job",
+        "tags": [
+          "Jobs"
+        ]
+      }
+    },
+    "/api/metricAlerts/v1": {
+      "post": {
+        "description": "Send a metric out of range alert for a monitored model. Required Permissions: None",
+        "operationId": "sendMetricAlert",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetricAlertRequestV1"
+              }
+            }
+          },
+          "description": "Details about the metric alert to send",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Send a metric alert",
+        "tags": [
+          "CustomMetrics"
+        ]
+      }
+    },
+    "/api/metricValues/v1": {
+      "post": {
+        "description": "Log metric values. Required Permissions: None",
+        "operationId": "logMetricValues",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewMetricValuesEnvelopeV1"
+              }
+            }
+          },
+          "description": "List of metric values to log",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Log metric values",
+        "tags": [
+          "CustomMetrics"
+        ]
+      }
+    },
+    "/api/metricValues/v1/{modelMonitoringId}/{metric}": {
+      "get": {
+        "description": "Retrieve metric values. Required Permissions: None",
+        "operationId": "retrieveMetricValues",
+        "parameters": [
+          {
+            "description": "ID of the monitored model",
+            "in": "path",
+            "name": "modelMonitoringId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of the metric to retrieve",
+            "in": "path",
+            "name": "metric",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Timestamp to filter metrics by referenceTimestamp >= startingReferenceTimestampInclusive. Timestamp should follow the RFC3339 format with timezone e.g. 2013-07-01T17:55:13-07:00",
+            "in": "query",
+            "name": "startingReferenceTimestampInclusive",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Timestamp to filter metrics by referenceTimestamp <= endingReferenceTimestampInclusive. Timestamp should follow the RFC3339 format with timezone e.g. 2013-07-01T17:55:13-07:00",
+            "in": "query",
+            "name": "endingReferenceTimestampInclusive",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricValuesEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Retrieve metric values",
+        "tags": [
+          "CustomMetrics"
+        ]
+      }
+    },
+    "/api/modelApis/async/v1/{asyncModelId}": {
+      "post": {
+        "description": "Request a prediction from an Async Model",
+        "operationId": "requestAsyncPrediction",
+        "parameters": [
+          {
+            "description": "Id of Async Model",
+            "in": "path",
+            "name": "asyncModelId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewAsyncPredictionV1"
+              }
+            }
+          },
+          "description": "Information for new Async Prediction",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncPredictionRequestEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "413": {
+            "$ref": "#/components/responses/413"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Request a prediction from an Async model",
+        "tags": [
+          "AsyncPredictions"
+        ]
+      }
+    },
+    "/api/modelApis/async/v1/{asyncModelId}/{asyncPredictionId}": {
+      "get": {
+        "description": "Retrieve the result of an Async Model prediction",
+        "operationId": "retrieveAsyncPredictionResult",
+        "parameters": [
+          {
+            "description": "Id of Async Model",
+            "in": "path",
+            "name": "asyncModelId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of Async Prediction",
+            "in": "path",
+            "name": "asyncPredictionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncPredictionEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Retrieve the result of an Async Model prediction",
+        "tags": [
+          "AsyncPredictions"
+        ]
+      }
+    },
+    "/api/organizations/v1/organizations": {
+      "get": {
+        "description": "Retrieve all Organizations of which this user is a member. Required permissions: `None`",
+        "operationId": "getUserOrgs",
+        "parameters": [
+          {
+            "description": "Optional value to filter organization names with. Must exactly match organization name.",
+            "in": "query",
+            "name": "nameFilter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "How many orgs from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of orgs to fetch. Defaults to 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedOrganizationEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get the Organizations for a user",
+        "tags": [
+          "Organizations"
+        ]
+      },
+      "post": {
+        "description": "Create a new Organization. Required permissions: `Must be logged in user`",
+        "operationId": "createOrg",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewOrganizationV1"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create an organization",
+        "tags": [
+          "Organizations"
+        ]
+      }
+    },
+    "/api/organizations/v1/organizations/all": {
+      "get": {
+        "description": "Get all organizations. Required permissions: `ManageOrganizations`",
+        "operationId": "getAllOrgs",
+        "parameters": [
+          {
+            "description": "Optional value to filter organization names with.",
+            "in": "query",
+            "name": "nameFilter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "How many orgs from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of orgs to fetch. Defaults to 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedOrganizationEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get all organizations. Only accessible to admin users.",
+        "tags": [
+          "Organizations"
+        ]
+      }
+    },
+    "/api/organizations/v1/organizations/{organizationId}": {
+      "get": {
+        "description": "Retrieve an Organization by its Id. Required permissions: `ViewOrganization`",
+        "operationId": "getOrg",
+        "parameters": [
+          {
+            "description": "Id of organization to retrieve. This is the id of the org in the users collection, not the organizations collection.",
+            "in": "path",
+            "name": "organizationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get an organization by Id",
+        "tags": [
+          "Organizations"
+        ]
+      }
+    },
+    "/api/organizations/v1/organizations/{organizationId}/user": {
+      "delete": {
+        "description": "Remove a user from an Organization. Required permissions: `EditMembers`",
+        "operationId": "removeUserFromOrg",
+        "parameters": [
+          {
+            "description": "Id of organization to add a user to. This is the id of the org in the users collection, not the organizations collection.",
+            "in": "path",
+            "name": "organizationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of user to remove from org.",
+            "in": "query",
+            "name": "memberToRemoveId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Remove a user from an org",
+        "tags": [
+          "Organizations"
+        ]
+      },
+      "put": {
+        "description": "Add a new user to an Organization. Required permissions: `EditMembers`",
+        "operationId": "addUserToOrg",
+        "parameters": [
+          {
+            "description": "Id of organization to add a user to. This is the id of the org in the users collection, not the organizations collection.",
+            "in": "path",
+            "name": "organizationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationMemberV1"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Add a user to an org",
+        "tags": [
+          "Organizations"
+        ]
+      }
+    },
+    "/api/projects/beta/projects": {
+      "get": {
+        "description": "Get projects that a user can see. Required permissions: `ListProject`. *Note:* This is a beta endpoint with known limitations.",
+        "operationId": "getProjects",
+        "parameters": [
+          {
+            "description": "How many Projects from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of Projects to fetch. Defaults to 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedProjectsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get Projects visible to user",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "post": {
+        "description": "Create a project. Required permissions: `CreateProject, UseFileStorage`. *Note:* This is a beta endpoint with known limitations.",
+        "operationId": "createProject",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewProjectV1"
+              }
+            }
+          },
+          "description": "Project to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/beta/projects/{projectId}": {
+      "delete": {
+        "description": "Archive a project by id. Required permissions: `ArchiveProject`. *Note:* This is a beta endpoint with known limitations.",
+        "operationId": "archiveProject",
+        "parameters": [
+          {
+            "description": "ID of the project to retrieve",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Archive project by id",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/beta/projects/{projectId}/copy-project": {
+      "post": {
+        "description": "Create a new project by copying an existing project and providing optional overrides. Specify a git repository to link to the copied project or copy the original project's git repository for the copied project.",
+        "operationId": "copyProjectBeta",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CopyProjectSpecBeta"
+              }
+            }
+          },
+          "description": "Information needed in order to copy a project.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectCopyResultEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a new project by copying an existing project and providing optional overrides. Deprecated.",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/beta/projects/{projectId}/files/{commitId}/{path}/content": {
+      "get": {
+        "description": "Return the raw contents of a file in a project at given commit.",
+        "operationId": "getProjectFileContents",
+        "parameters": [
+          {
+            "description": "Id of the project to return files for",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of a commit in the project repository to list files from",
+            "in": "path",
+            "name": "commitId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path in the project's repository to the file. It must be url-encoded and is case-sensitive.",
+            "example": "nested%2Ffolder%2Ffile.ext",
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Success. It returns a stream of data with the file content, specifying the appropriate\nmedia type based on the file extension in a best-effort basis.\n",
+            "x-domino-binary-stream": true
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Returns the contents of a file",
+        "tags": [
+          "ProjectsFiles"
+        ]
+      }
+    },
+    "/api/projects/beta/projects/{projectId}/results-settings": {
+      "get": {
+        "operationId": "getProjectResultSettings",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResultsSettingsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get project result settings",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "put": {
+        "operationId": "updateProjectResultSettings",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectResultsSettingsV1"
+              }
+            }
+          },
+          "description": "Project status",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResultsSettingsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update project result settings",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}": {
+      "get": {
+        "description": "Get project by id. Required permissions: `ListProject`",
+        "operationId": "getProjectById",
+        "parameters": [
+          {
+            "description": "ID of the project to retrieve",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get Project by Id",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/collaborators": {
+      "post": {
+        "description": "Add a collaborator to this project. Required permissions: `ManageCollaborators`",
+        "operationId": "addCollaboratorToProject",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectCollaboratorV1"
+              }
+            }
+          },
+          "description": "Collaborator ID",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectCollaboratorEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Add a collaborator to this project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/collaborators/{collaboratorId}": {
+      "delete": {
+        "description": "Remove a collaborator from the project. Required permissions: `ManageCollaborators`",
+        "operationId": "removeCollaboratorFromProject",
+        "parameters": [
+          {
+            "description": "ID of the project to remove collaborator from",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ID of the collaborator to remove",
+            "in": "path",
+            "name": "collaboratorId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Remove a collaborator from project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/copy-project": {
+      "post": {
+        "description": "Create a new project by copying an existing project and providing optional overrides. Specify a git repository to link to the copied project or copy the original project's git repository for the copied project.",
+        "operationId": "copyProject",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CopyProjectSpecV1"
+              }
+            }
+          },
+          "description": "Information needed in order to copy a project.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectCopyResultEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "429": {
+            "$ref": "#/components/responses/429"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a new project by copying an existing project and providing optional overrides.",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/goals": {
+      "get": {
+        "description": "Get goals in this project. Required permissions: `ListProject`",
+        "operationId": "getProjectGoals",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectGoalsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get goals in this project",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "post": {
+        "description": "Add a goal to this project. Required permissions: `Edit`",
+        "operationId": "addGoalToProject",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewProjectGoalV1"
+              }
+            }
+          },
+          "description": "Goal to add",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectGoalEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Add a goal to this project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/goals/{goalId}": {
+      "delete": {
+        "description": "Delete a project goal. Required permissions: `Edit`",
+        "operationId": "deleteProjectGoal",
+        "parameters": [
+          {
+            "description": "ID of the project to delete goal from",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ID of the goal to delete",
+            "in": "path",
+            "name": "goalId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Delete a project goal",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "patch": {
+        "description": "Update project goal status. Required permissions: `Edit`",
+        "operationId": "updateProjectGoal",
+        "parameters": [
+          {
+            "description": "Project ID of the goal",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ID of the goal to update",
+            "in": "path",
+            "name": "goalId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectGoalForUpdateV1"
+              }
+            }
+          },
+          "description": "Project goal for update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectGoalEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update project goal status",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/repositories": {
+      "get": {
+        "description": "Get all imported git repositories in this project. Required permissions: `ListProject`",
+        "operationId": "getImportedRepos",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "How many Projects from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of Projects to fetch. Defaults to 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedGitRepositoriesEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get all imported git repositories in this project",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "post": {
+        "description": "Add an imported git repository to this project. Required permissions: `ChangeProjectSettings`",
+        "operationId": "addRepoToProject",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewProjectGitRepositoryV1"
+              }
+            }
+          },
+          "description": "Repository to add",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectGitRepositoryEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Add an imported git repository to this project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/repositories/{repositoryId}": {
+      "delete": {
+        "description": "Remove an imported repository from the project. Required permissions: `ChangeProjectSettings`",
+        "operationId": "removeRepoFromProject",
+        "parameters": [
+          {
+            "description": "ID of the project to remove goal from",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ID of the repository to remove",
+            "in": "path",
+            "name": "repositoryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Remove an imported repository from project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/shared-datasets": {
+      "get": {
+        "description": "List shared datasets used by a project. Required permissions: `GetDatasetsRw`",
+        "operationId": "listProjectSharedDatasets",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SharedDatasetsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get shared datasets that a project uses",
+        "tags": [
+          "ProjectSharedDatasets"
+        ]
+      },
+      "post": {
+        "description": "Link a shared dataset to this project. Required permissions: `ManageDatasetsRw,UseFileStorage`",
+        "operationId": "linkProjectToDataset",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetToAddV1"
+              }
+            }
+          },
+          "description": "Dataset ID",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SharedDatasetsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Link a shared dataset to this project",
+        "tags": [
+          "ProjectSharedDatasets"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/shared-datasets/{datasetId}": {
+      "delete": {
+        "description": "Unlink the dataset with the specified Id from a project. Required permissions: `ManageDatasetsRw,UseFileStorage`",
+        "operationId": "unlinkDatasetFromProject",
+        "parameters": [
+          {
+            "description": "Id of project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of shared dataset to remove",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "Unlink a shared dataset from this project",
+        "tags": [
+          "ProjectSharedDatasets"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/status": {
+      "put": {
+        "description": "Update the status of a project. Required permissions: `Edit`",
+        "operationId": "updateProjectStatus",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectStatusV1"
+              }
+            }
+          },
+          "description": "Project status",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectStatusEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update project status",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/workspaces/{workspaceId}/sessions": {
+      "post": {
+        "description": "Creates a new session given an existing workspace. Required permissions: `OpenWorkspace`, `UseGlobalCompute`",
+        "operationId": "createWorkspaceSession",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "workspaceId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewWorkspaceSessionV1"
+              }
+            }
+          },
+          "description": "New session parameters",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceSessionCreatedEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create workspace session",
+        "tags": [
+          "Workspaces"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1": {
+      "get": {
+        "description": "Get registered models that a user can see.",
+        "operationId": "getRegisteredModels",
+        "parameters": [
+          {
+            "description": "Project ID of requested models.",
+            "in": "query",
+            "name": "projectId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Search parameter to retrieve models from Mlflow (currently supports name and tags)",
+            "in": "query",
+            "name": "searchPattern",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Pagination token to go to the next page based on a previous search query.",
+            "in": "query",
+            "name": "pageToken",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max number of Registered Models to fetch. Defaults to 25.",
+            "in": "query",
+            "name": "maxResults",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "List of columns for ordering search results, which can include model name and last updated timestamp with an optional ���DESC��� or ���ASC��� annotation, where ���ASC��� is the default. Tiebreaks are done by model name ASC.",
+            "in": "query",
+            "name": "orderBy",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedRegisteredModelsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get Registered Models visible to user",
+        "tags": [
+          "RegisteredModels"
+        ]
+      },
+      "post": {
+        "description": "Create a new a Registered Model from an experiment run",
+        "operationId": "createRegisteredModelFromRun",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewRegisteredModelV1"
+              }
+            }
+          },
+          "description": "Details of the registered model to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisteredModelV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a new a Registered Model from an experiment run",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/access/{projectId}": {
+      "post": {
+        "description": "Request access to a project",
+        "operationId": "requestProjectAccess",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Request access to a project",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/names": {
+      "get": {
+        "description": "Get a list of Registered Models' names visible to user.",
+        "operationId": "getRegisteredModelNames",
+        "parameters": [
+          {
+            "description": "Search filter by model name",
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "How many Registered Models from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of Registered Models to fetch. Defaults to 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Project ID of requested models.",
+            "in": "query",
+            "name": "projectId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedRegisteredModelNamesV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get a list of Registered Models' names visible to user",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/ui": {
+      "get": {
+        "description": "Get registered models that a user can see.",
+        "operationId": "getRegisteredModelsForUI",
+        "parameters": [
+          {
+            "description": "Project ID of requested models.",
+            "in": "query",
+            "name": "projectId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Search parameter to retrieve models from Mlflow (currently supports name and tags)",
+            "in": "query",
+            "name": "searchPattern",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "globallyDiscoverable flag to indicate if we want to return globally discoverable models. Defaults to false.",
+            "in": "query",
+            "name": "globallyDiscoverable",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Pagination token to go to the next page based on a previous search query.",
+            "in": "query",
+            "name": "pageToken",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max number of Registered Models to fetch. Defaults to 25.",
+            "in": "query",
+            "name": "maxResults",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "List of columns for ordering search results, which can include model name and last updated timestamp with an optional ���DESC��� or ���ASC��� annotation, where ���ASC��� is the default.",
+            "in": "query",
+            "name": "orderBy",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedRegisteredModelsForUIEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get Registered Models visible to user",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/versions/stages/projects/{projectId}": {
+      "get": {
+        "description": "Get registered model version stages for a project",
+        "operationId": "getRegisteredModelVersionStages",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "includeDefaults flag to indicate if we want to return global stages if no overrides are set for the project",
+            "in": "query",
+            "name": "includeDefaults",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisteredModelVersionStagesResponseV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get registered model version stages for a project",
+        "tags": [
+          "RegisteredModels"
+        ]
+      },
+      "put": {
+        "description": "Set registered model version stages for a project",
+        "operationId": "setRegisteredModelVersionStages",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisteredModelVersionStagesV1"
+              }
+            }
+          },
+          "description": "List of registered model version stages to set for a project",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisteredModelVersionStagesResponseV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Set registered model version stages for a project",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/{modelName}": {
+      "get": {
+        "description": "Get a specific Registered Model",
+        "operationId": "getRegisteredModelByName",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisteredModelV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get a specific Registered Model",
+        "tags": [
+          "RegisteredModels"
+        ]
+      },
+      "patch": {
+        "description": "Update a Registered Model",
+        "operationId": "patchRegisteredModelByName",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PatchRegisteredModelV1"
+              }
+            }
+          },
+          "description": "Details of the model to update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisteredModelV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update a Registered Model",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/{modelName}/modelapis": {
+      "get": {
+        "description": "Gets all active model Apis that were deployed from a given Registered Model",
+        "operationId": "getModelApisFromRegisteredModel",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedRegisteredModelVersionModelApiEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Returns list of Model APIs deployed from a specific Registered Model",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/{modelName}/versions": {
+      "get": {
+        "description": "Get all versions of a Registered Model",
+        "operationId": "getRegisteredModelVersions",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Offset for pagination from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of Registered Models to fetch. Defaults to 20",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedRegisteredModelVersionOverviewEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get all versions of a Registered Model",
+        "tags": [
+          "RegisteredModels"
+        ]
+      },
+      "post": {
+        "description": "Create a new version of a Registered Model",
+        "operationId": "createRegisteredModelVersionFromRun",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewRegisteredModelVersionV1"
+              }
+            }
+          },
+          "description": "Details of the model version to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisteredModelVersionDetailsV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a new version of a Registered Model",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/{modelName}/versions/{version}": {
+      "get": {
+        "description": "Get a specific version of a Registered Model",
+        "operationId": "getRegisteredModelVersion",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version of the registered model",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisteredModelVersionDetailsV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get a specific version of a Registered Model",
+        "tags": [
+          "RegisteredModels"
+        ]
+      },
+      "patch": {
+        "description": "Update a Registered Model version",
+        "operationId": "updateRegisteredModelVersion",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version of the registered model",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatedRegisteredModelVersionV1"
+              }
+            }
+          },
+          "description": "Updated details of the registered model version",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisteredModelVersionDetailsV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update a Registered Model version",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/{modelName}/versions/{version}/modelapis": {
+      "get": {
+        "description": "Gets all active model Apis that were deployed from a given Registered Model Version",
+        "operationId": "getModelApisFromRegisteredModelVersion",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version of the registered model",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedRegisteredModelVersionModelApiEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Returns list of Model APIs deployed from a specific Registered Model Version",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/{modelName}/versions/{version}/reviews": {
+      "post": {
+        "description": "Create a review of a Registered Model",
+        "operationId": "createRegisteredModelReview",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version of the registered model",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewRegisteredModelReviewV1"
+              }
+            }
+          },
+          "description": "Details about the review to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a review of a Registered Model",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/{modelName}/versions/{version}/reviews/{modelReviewId}": {
+      "patch": {
+        "description": "Update a review of a Registered Model by 1) adding or remove reviewers with an option to change notes, or 2) changing status to canceled with an an option to change notes, but cannot do both simultaneously, or 3) changing only notes",
+        "operationId": "updateRegisteredModelReview",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version of the registered model",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Id of the model review to edit",
+            "in": "path",
+            "name": "modelReviewId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatedRegisteredModelReviewV1"
+              }
+            }
+          },
+          "description": "Details about the review edit",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Updated"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update a review of a Registered Model - add or remove reviewers with an option to change notes, or change status to canceled with an an option to change notes but cannot do both simultaneously or simply change notes",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/{modelName}/versions/{version}/reviews/{modelReviewId}/responses": {
+      "post": {
+        "description": "Create a response to a Registered Model review",
+        "operationId": "createRegisteredModelReviewResponse",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version of the registered model",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Id of Model Review",
+            "in": "path",
+            "name": "modelReviewId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewRegisteredModelReviewResponseV1"
+              }
+            }
+          },
+          "description": "Details about the review to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a response to a Registered Model review",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/{modelName}/versions/{version}/reviewstages": {
+      "get": {
+        "description": "Get registered model version stages valid for starting a model review",
+        "operationId": "getModelVersionReviewStages",
+        "parameters": [
+          {
+            "description": "model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "version of the model",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisteredModelVersionReviewStagesResponseV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get registered model version stages valid for starting a model review",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodels/v1/{modelName}/versions/{version}/stages/validation": {
+      "put": {
+        "description": "Validates whether a model version can transition to a given stage",
+        "operationId": "validateRegisteredModelVersionStage",
+        "parameters": [
+          {
+            "description": "Registered model name",
+            "in": "path",
+            "name": "modelName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version of the registered model",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisteredModelVersionStageValidationV1"
+              }
+            }
+          },
+          "description": "The information of the stage to transition",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Validates whether a model version can transition to a given stage",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/registeredmodelstages/v1": {
+      "get": {
+        "description": "Get the possible stages of a Registered Model",
+        "operationId": "getRegisteredModelStages",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisteredModelStageEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get the possible stages of a Registered Model",
+        "tags": [
+          "RegisteredModels"
+        ]
+      }
+    },
+    "/api/users/beta/credentials/{userId}": {
+      "get": {
+        "description": "Retrieve a users git credentials. Required permissions: `UpdateUser`. *Note:* This is a beta endpoint with known limitations.",
+        "operationId": "getUserGitCreds",
+        "parameters": [
+          {
+            "description": "Id of the User to fetch creds for",
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedGitCredentialsAccessorEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get git credential accessor for a User",
+        "tags": [
+          "Users"
+        ]
+      }
+    },
+    "/api/users/v1/self": {
+      "get": {
+        "description": "Retrieve the current user. Required permissions: `None`",
+        "operationId": "getCurrentUser",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get the current user",
+        "tags": [
+          "Users"
+        ]
+      }
+    },
+    "/api/users/v1/users": {
+      "get": {
+        "description": "Retrieves all users visible to the current user. Required permissions: `None`",
+        "operationId": "getVisibleUsers",
+        "parameters": [
+          {
+            "description": "How many users from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of users to fetch. Defaults to 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedUserEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get all users visible to the current user",
+        "tags": [
+          "Users"
+        ]
+      }
+    },
+    "/athenaConfigs": {
+      "put": {
+        "description": "Set AWS Billing API Configuration",
+        "operationId": "setAthenaConfigs",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AthenaBillingConfigsV1"
+              }
+            }
+          },
+          "description": "AWS Billing API Config",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AthenaBillingConfigsV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Set AWS Billing API Configuration",
+        "tags": [
+          "Cost"
+        ]
+      }
+    },
+    "/licenseKey": {
+      "put": {
+        "description": "Add kubecost license key",
+        "operationId": "addKubecostLicenseKey",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KubecostLicenseV1"
+              }
+            }
+          },
+          "description": "Kubecost License Key",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KubecostLicenseResponseV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Add kubecost license key",
+        "tags": [
+          "Cost"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "DominoApiKey": []
+    },
+    {
+      "BearerAuthentication": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "CustomMetrics"
+    },
+    {
+      "name": "DatasetRw"
+    },
+    {
+      "name": "DataSource"
+    },
+    {
+      "name": "Cost"
+    },
+    {
+      "name": "Environments"
+    },
+    {
+      "name": "Jobs"
+    },
+    {
+      "name": "Organizations"
+    },
+    {
+      "name": "Projects"
+    },
+    {
+      "name": "Registered Models"
+    },
+    {
+      "name": "Users"
+    },
+    {
+      "name": "AsyncPredictions"
+    }
+  ]
+}


### PR DESCRIPTION
- Updates domino-openapi.json spec with changes to 5.9.1 including resolving validation issues
- Adds domino-public-api.json spec with /v1 Domino endpoints, needed for environment image creation and dataset deep copy for project copy endpoint
- Edit an endpoint required request parameter `path` for `DatasetRwApi.getFilesInSnapshot()` that was causing some strife with application development