### PR TITLE
Rebuilt using the internal and public API documents from Domino 5.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.ksmpartners</groupId>
     <artifactId>domino-java-client</artifactId>
     <packaging>jar</packaging>
-    <version>5.9.1.4</version>
+    <version>5.10.1.0</version>
     <name>Domino Data Lab API Client</name>
     <description>Domino Data Lab API Client to connect to Domino web services using Java HTTP Client.</description>
     <url>https://github.com/ksmpartners/domino-java-client</url>

--- a/src/conf/domino-openapi.json
+++ b/src/conf/domino-openapi.json
@@ -31,16 +31,6 @@
         },
         "description": "An internal error prevented the server from performing this action"
       },
-      "ModelProductErrorResponse": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
-            }
-          }
-        },
-        "description": ""
-      },
       "NotFound": {
         "content": {
           "application/json": {
@@ -115,6 +105,19 @@
           "Ray",
           "Dask",
           "MPI"
+        ],
+        "type": "string"
+      },
+      "DocumentType": {
+        "description": "List of searchable document types",
+        "enum": [
+          "project",
+          "file",
+          "run",
+          "model",
+          "environment",
+          "comment",
+          "dataset"
         ],
         "type": "string"
       },
@@ -390,7 +393,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -425,7 +428,7 @@
       "domino.activity.api.ActivityPagination": {
         "properties": {
           "latestTimeStamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "pageSize": {
@@ -1351,6 +1354,26 @@
           "commentCount"
         ]
       },
+      "domino.admin.interface.AdminProjectsSettings": {
+        "properties": {
+          "sizeColumnEnabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "sizeColumnEnabled"
+        ]
+      },
+      "domino.admin.interface.AdminSettings": {
+        "properties": {
+          "projects": {
+            "$ref": "#/components/schemas/domino.admin.interface.AdminProjectsSettings"
+          }
+        },
+        "required": [
+          "projects"
+        ]
+      },
       "domino.admin.interface.ComputeClusterOverview": {
         "properties": {
           "clusterName": {
@@ -1610,6 +1633,30 @@
           "setting"
         ]
       },
+      "domino.admin.interface.CreateServiceAccountRequest": {
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "email"
+        ]
+      },
+      "domino.admin.interface.CreateServiceAccountTokenRequest": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
       "domino.admin.interface.ExecutionOverview": {
         "properties": {
           "computeClusterOverviews": {
@@ -1692,6 +1739,25 @@
           "workloadType",
           "computeClusterOverviews",
           "onDemandSparkExecutionUnits"
+        ]
+      },
+      "domino.admin.interface.GlobalBanner": {
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "isClosable": {
+            "type": "boolean"
+          },
+          "reappearTimeAfterCloseInSec": {
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "content",
+          "isClosable"
         ]
       },
       "domino.admin.interface.HardwareTierOverview": {
@@ -1793,6 +1859,89 @@
           "totalMatches"
         ]
       },
+      "domino.admin.interface.ServiceAccount": {
+        "properties": {
+          "email": {
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "idpId": {
+            "nullable": true,
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "id"
+        ]
+      },
+      "domino.admin.interface.ServiceAccountTokenMetadata": {
+        "properties": {
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "expiresAt": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "isValid": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "serviceAccountIdpId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "serviceAccountIdpId",
+          "isValid",
+          "createdAt"
+        ]
+      },
+      "domino.admin.interface.ServiceAccountTokenMetadataAndToken": {
+        "properties": {
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "expiresAt": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "isValid": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "serviceAccountIdpId": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "serviceAccountIdpId",
+          "token",
+          "isValid",
+          "createdAt"
+        ]
+      },
       "domino.admin.interface.UserProjectEntry": {
         "properties": {
           "archived": {
@@ -1826,6 +1975,10 @@
             "format": "int64",
             "type": "integer"
           },
+          "size": {
+            "$ref": "#/components/schemas/domino.admin.interface.UserProjectSizeInKB",
+            "nullable": true
+          },
           "totalRunTimeInHours": {
             "format": "double",
             "type": "number"
@@ -1840,8 +1993,32 @@
           "archived"
         ]
       },
+      "domino.admin.interface.UserProjectSizeInKB": {
+        "properties": {
+          "dominoFileSystem": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "lastUpdated",
+          "unit"
+        ]
+      },
       "domino.admin.interface.WhiteLabelConfigurations": {
         "properties": {
+          "admin": {
+            "$ref": "#/components/schemas/domino.admin.interface.AdminSettings",
+            "nullable": true
+          },
           "appLogo": {
             "nullable": true,
             "type": "string"
@@ -1871,6 +2048,10 @@
           },
           "gitCredentialsDescription": {
             "type": "string"
+          },
+          "globalBanner": {
+            "$ref": "#/components/schemas/domino.admin.interface.GlobalBanner",
+            "nullable": true
           },
           "helpContentUrl": {
             "type": "string"
@@ -1905,6 +2086,13 @@
           "pageFooter": {
             "type": "string"
           },
+          "pdfAppName": {
+            "type": "string"
+          },
+          "pdfTemplateUrl": {
+            "nullable": true,
+            "type": "string"
+          },
           "showSupportButton": {
             "type": "boolean"
           },
@@ -1923,6 +2111,7 @@
           "gitCredentialsDescription",
           "helpContentUrl",
           "supportUrl",
+          "pdfAppName",
           "hideAddProjectAction",
           "hidePopularProjects",
           "hideDownloadDominoCli",
@@ -1937,6 +2126,345 @@
           "showSupportButton",
           "supportEmail"
         ]
+      },
+      "domino.admin.usermanagement.api.AdminUserManagementUser": {
+        "properties": {
+          "createdAtTimestampMs": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "email": {
+            "nullable": true,
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "idpId": {
+            "type": "string"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "isDominoEmployee": {
+            "type": "boolean"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "licenseName": {
+            "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/domino.admin.usermanagement.api.AdminUserManagementUserMetadata"
+          },
+          "roles": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "idpId",
+          "firstName",
+          "lastName",
+          "fullName",
+          "username",
+          "roles",
+          "isActive",
+          "isDominoEmployee",
+          "licenseName",
+          "createdAtTimestampMs",
+          "metadata"
+        ]
+      },
+      "domino.admin.usermanagement.api.AdminUserManagementUserMetadata": {
+        "properties": {
+          "isManagableByViewer": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "isManagableByViewer"
+        ]
+      },
+      "domino.admin.usermanagement.api.AdminUserManagementUserWithUsage": {
+        "properties": {
+          "usage": {
+            "$ref": "#/components/schemas/domino.admin.usermanagement.api.BriefUserUsageReport",
+            "nullable": true
+          },
+          "user": {
+            "$ref": "#/components/schemas/domino.admin.usermanagement.api.AdminUserManagementUser"
+          }
+        },
+        "required": [
+          "user"
+        ]
+      },
+      "domino.admin.usermanagement.api.AggregateUserActivityReport": {
+        "properties": {
+          "enabledUsers": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "hideLicenseType": {
+            "type": "boolean"
+          },
+          "licenseQuota": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "practitioners": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "recentUsageDays": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "reportEndDate": {
+            "nullable": true,
+            "type": "string"
+          },
+          "resultsConsumers": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "roleBasedCounts": {
+            "$ref": "#/components/schemas/StringIntMap"
+          }
+        },
+        "required": [
+          "enabledUsers",
+          "practitioners",
+          "resultsConsumers",
+          "licenseQuota",
+          "recentUsageDays",
+          "hideLicenseType",
+          "roleBasedCounts"
+        ]
+      },
+      "domino.admin.usermanagement.api.AllowedActions": {
+        "properties": {
+          "createUsers": {
+            "type": "boolean"
+          },
+          "enableDisableUsers": {
+            "type": "boolean"
+          },
+          "manageFeatureFlags": {
+            "type": "boolean"
+          },
+          "markUnmarkUserAsDominoEmployee": {
+            "type": "boolean"
+          },
+          "resetPasswords": {
+            "type": "boolean"
+          },
+          "saveRoles": {
+            "type": "boolean"
+          },
+          "viewDataAnalystColumn": {
+            "type": "boolean"
+          },
+          "viewExternalOrgs": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "createUsers",
+          "enableDisableUsers",
+          "manageFeatureFlags",
+          "markUnmarkUserAsDominoEmployee",
+          "resetPasswords",
+          "saveRoles",
+          "viewExternalOrgs",
+          "viewDataAnalystColumn"
+        ]
+      },
+      "domino.admin.usermanagement.api.BriefUserUsageReport": {
+        "properties": {
+          "licenseType": {
+            "type": "string"
+          },
+          "mostRecentActivity": {
+            "nullable": true,
+            "type": "string"
+          },
+          "practitionerWorkloadsTotal": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "projectsRecent": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "projectsTotal": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "runsRecent": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "runsTotal": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "userId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "userId",
+          "practitionerWorkloadsTotal",
+          "runsTotal",
+          "runsRecent",
+          "projectsTotal",
+          "projectsRecent",
+          "licenseType"
+        ]
+      },
+      "domino.admin.usermanagement.api.UpdateUserRequest": {
+        "properties": {
+          "enabled": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "isDominoEmployee": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "roles": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        }
+      },
+      "domino.admin.usermanagement.api.UsersMetadata": {
+        "properties": {
+          "allowedActions": {
+            "$ref": "#/components/schemas/domino.admin.usermanagement.api.AllowedActions"
+          },
+          "limit": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "offset": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "offset",
+          "limit",
+          "totalCount",
+          "allowedActions"
+        ]
+      },
+      "domino.admin.usermanagement.api.UsersResponse": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/domino.admin.usermanagement.api.UsersMetadata"
+          },
+          "users": {
+            "items": {
+              "$ref": "#/components/schemas/domino.admin.usermanagement.api.AdminUserManagementUser"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "users",
+          "metadata"
+        ]
+      },
+      "domino.admin.usermanagement.api.UsersWithUsageMetadata": {
+        "properties": {
+          "allowedActions": {
+            "$ref": "#/components/schemas/domino.admin.usermanagement.api.AllowedActions"
+          },
+          "limit": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "offset": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "offset",
+          "limit",
+          "totalCount",
+          "allowedActions"
+        ]
+      },
+      "domino.admin.usermanagement.api.UsersWithUsageResponse": {
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/domino.admin.usermanagement.api.UsersWithUsageMetadata"
+          },
+          "users": {
+            "items": {
+              "$ref": "#/components/schemas/domino.admin.usermanagement.api.AdminUserManagementUserWithUsage"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "users",
+          "metadata"
+        ]
+      },
+      "domino.admin.web.MenuItemDto": {
+        "properties": {
+          "allowed": {
+            "type": "boolean"
+          },
+          "code": {
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/domino.admin.web.MenuItemDto"
+            },
+            "type": "array"
+          },
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
       },
       "domino.api.ErrorResponse": {
         "properties": {
@@ -1970,20 +2498,6 @@
           "ownerUsername",
           "projectName"
         ]
-      },
-      "domino.common.executor.run.RunMemoryLimitDto": {
-        "properties": {
-          "memoryLimitMegabytes": {
-            "format": "int32",
-            "nullable": true,
-            "type": "integer"
-          },
-          "memorySwapLimitMegabytes": {
-            "format": "int32",
-            "nullable": true,
-            "type": "integer"
-          }
-        }
       },
       "domino.common.gateway.runs.ComputeClusterDetails": {
         "properties": {
@@ -2763,7 +3277,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -2803,7 +3317,7 @@
             "$ref": "#/components/schemas/domino.common.modelproduct.AppResourceUsage"
           },
           "started": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "status": {
@@ -2846,7 +3360,7 @@
             "type": "string"
           },
           "started": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "status": {
@@ -2928,7 +3442,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -3711,15 +4225,15 @@
           },
           "executionType": {
             "enum": [
-              "Other",
-              "SSHProxy",
               "Model API",
               "Endpoint",
               "App",
               "Scheduled",
               "Launcher",
               "Batch",
-              "Workspace"
+              "Workspace",
+              "Other",
+              "SSHProxy"
             ],
             "nullable": true,
             "type": "string"
@@ -3774,11 +4288,23 @@
           "resourceKind": {
             "enum": [
               "Other",
-              "Event",
-              "Deployment",
+              "Role",
+              "StatefulSet",
               "Job",
               "Service",
-              "Pod"
+              "ServiceAccount",
+              "PersistentVolume",
+              "Pod",
+              "NetworkPolicy",
+              "PriorityClass",
+              "RoleBinding",
+              "Event",
+              "ConfigMap",
+              "Node",
+              "HorizontalPodAutoscaler",
+              "Secret",
+              "PersistentVolumeClaim",
+              "Deployment"
             ],
             "nullable": true,
             "type": "string"
@@ -3822,8 +4348,7 @@
           "elapsedMillis",
           "creationTime",
           "updateTime"
-        ],
-        "type": "object"
+        ]
       },
       "domino.computegrid.ExecutionUnitOverview": {
         "properties": {
@@ -3871,7 +4396,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -3910,7 +4435,6 @@
             "type": "string"
           },
           "extraInfo": {
-            "additionalProperties": true,
             "nullable": true,
             "type": "object"
           },
@@ -4092,7 +4616,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -4118,7 +4642,9 @@
               "UserOnly",
               "BasicOptional",
               "NoAuth",
-              "ClientIdSecret"
+              "ClientIdSecret",
+              "OAuthToken",
+              "APIKey"
             ],
             "type": "string"
           },
@@ -4721,7 +5247,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -5321,6 +5847,7 @@
           "UpdateDatasetRwV2",
           "PerformDatasetRwActionsAsAdminV2"
         ],
+        "properties": {},
         "type": "string"
       },
       "domino.datasetrw.api.DatasetRwProjectDetailsDto": {
@@ -5507,6 +6034,7 @@
           "Active",
           "Pending"
         ],
+        "properties": {},
         "type": "string"
       },
       "domino.datasetrw.api.DatasetRwSnapshotAdminSummaryDto": {
@@ -5684,6 +6212,40 @@
           "isReadWrite"
         ]
       },
+      "domino.datasetrw.api.DatasetRwStorageUsageDto": {
+        "properties": {
+          "isAtEmailThreshold": {
+            "type": "boolean"
+          },
+          "isAtWarningThreshold": {
+            "type": "boolean"
+          },
+          "limit": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "quotaId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "targetId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "totalStorageUsed": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "quotaId",
+          "limit",
+          "totalStorageUsed",
+          "isAtWarningThreshold",
+          "isAtEmailThreshold"
+        ],
+        "type": "object"
+      },
       "domino.datasetrw.api.DatasetRwSummaryDto": {
         "properties": {
           "description": {
@@ -5754,7 +6316,7 @@
             "type": "string"
           },
           "lastTouched": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "uploadKey": {
@@ -6017,6 +6579,10 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "targetRelativePath": {
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [
@@ -6195,7 +6761,8 @@
               "TabularS3GlueConfig",
               "TeradataConfig",
               "TrinoConfig",
-              "VerticaConfig"
+              "VerticaConfig",
+              "PineconeConfig"
             ],
             "type": "string"
           },
@@ -6295,7 +6862,9 @@
               "UserOnly",
               "BasicOptional",
               "NoAuth",
-              "ClientIdSecret"
+              "ClientIdSecret",
+              "OAuthToken",
+              "APIKey"
             ],
             "type": "string"
           },
@@ -6345,7 +6914,8 @@
               "TabularS3GlueConfig",
               "TeradataConfig",
               "TrinoConfig",
-              "VerticaConfig"
+              "VerticaConfig",
+              "PineconeConfig"
             ],
             "type": "string"
           },
@@ -6490,6 +7060,10 @@
             },
             "type": "array"
           },
+          "dataSourceId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
           "dataSourceName": {
             "type": "string"
           },
@@ -6524,7 +7098,8 @@
               "TabularS3GlueConfig",
               "TeradataConfig",
               "TrinoConfig",
-              "VerticaConfig"
+              "VerticaConfig",
+              "PineconeConfig"
             ],
             "type": "string"
           },
@@ -6546,7 +7121,8 @@
           "engineType",
           "dataPlaneIds",
           "availableHardwareTiers",
-          "dataSourceName"
+          "dataSourceName",
+          "dataSourceId"
         ]
       },
       "domino.datasource.api.EngineConfig": {
@@ -6616,7 +7192,9 @@
           "BasicOptional",
           "UserOnly",
           "NoAuth",
-          "ClientIdSecret"
+          "ClientIdSecret",
+          "APIKey",
+          "OAuthToken"
         ],
         "type": "string"
       },
@@ -6624,7 +7202,8 @@
         "enum": [
           "Native",
           "Starburst",
-          "StarburstSelfService"
+          "StarburstSelfService",
+          "ReverseProxy"
         ],
         "type": "string"
       },
@@ -6703,6 +7282,7 @@
           "NetezzaConfig",
           "OracleConfig",
           "PalantirConfig",
+          "PineconeConfig",
           "PostgreSQLConfig",
           "RedshiftConfig",
           "S3Config",
@@ -6765,7 +7345,8 @@
       "domino.datasource.model.StorageType": {
         "enum": [
           "Tabular",
-          "ObjectStore"
+          "ObjectStore",
+          "Vector"
         ],
         "type": "string"
       },
@@ -6793,7 +7374,9 @@
               "UserOnly",
               "BasicOptional",
               "NoAuth",
-              "ClientIdSecret"
+              "ClientIdSecret",
+              "OAuthToken",
+              "APIKey"
             ],
             "type": "string"
           },
@@ -6847,11 +7430,16 @@
               "TabularS3GlueConfig",
               "TeradataConfig",
               "TrinoConfig",
-              "VerticaConfig"
+              "VerticaConfig",
+              "PineconeConfig"
             ],
             "type": "string"
           },
           "database": {
+            "nullable": true,
+            "type": "string"
+          },
+          "environment": {
             "nullable": true,
             "type": "string"
           },
@@ -6891,6 +7479,10 @@
             "nullable": true,
             "type": "string"
           },
+          "subfolder": {
+            "nullable": true,
+            "type": "string"
+          },
           "visibleCredential": {
             "nullable": true,
             "type": "string"
@@ -6922,7 +7514,9 @@
               "UserOnly",
               "BasicOptional",
               "NoAuth",
-              "ClientIdSecret"
+              "ClientIdSecret",
+              "OAuthToken",
+              "APIKey"
             ],
             "type": "string"
           },
@@ -6970,7 +7564,8 @@
               "TabularS3GlueConfig",
               "TeradataConfig",
               "TrinoConfig",
-              "VerticaConfig"
+              "VerticaConfig",
+              "PineconeConfig"
             ],
             "type": "string"
           },
@@ -7144,11 +7739,16 @@
               "TabularS3GlueConfig",
               "TeradataConfig",
               "TrinoConfig",
-              "VerticaConfig"
+              "VerticaConfig",
+              "PineconeConfig"
             ],
             "type": "string"
           },
           "database": {
+            "nullable": true,
+            "type": "string"
+          },
+          "environment": {
             "nullable": true,
             "type": "string"
           },
@@ -7184,6 +7784,10 @@
             "nullable": true,
             "type": "string"
           },
+          "subfolder": {
+            "nullable": true,
+            "type": "string"
+          },
           "warehouse": {
             "nullable": true,
             "type": "string"
@@ -7209,7 +7813,9 @@
               "UserOnly",
               "BasicOptional",
               "NoAuth",
-              "ClientIdSecret"
+              "ClientIdSecret",
+              "OAuthToken",
+              "APIKey"
             ],
             "type": "string"
           },
@@ -7453,6 +8059,10 @@
             },
             "type": "array"
           },
+          "templateMetadata": {
+            "$ref": "#/components/schemas/domino.environments.api.EnvironmentTemplateMetadata",
+            "nullable": true
+          },
           "visibility": {
             "enum": [
               "Global",
@@ -7496,12 +8106,16 @@
       },
       "domino.environments.api.EnvironmentPermissions": {
         "properties": {
+          "canArchive": {
+            "type": "boolean"
+          },
           "canEdit": {
             "type": "boolean"
           }
         },
         "required": [
-          "canEdit"
+          "canEdit",
+          "canArchive"
         ]
       },
       "domino.environments.api.EnvironmentPermissionsResult": {
@@ -7632,6 +8246,9 @@
             "pattern": "^[0-9a-f]{24}$",
             "type": "string"
           },
+          "environmentName": {
+            "type": "string"
+          },
           "id": {
             "pattern": "^[0-9a-f]{24}$",
             "type": "string"
@@ -7686,6 +8303,7 @@
         "required": [
           "id",
           "environmentId",
+          "environmentName",
           "imageType",
           "isRestricted",
           "isBuilt",
@@ -7696,6 +8314,10 @@
       },
       "domino.environments.api.EnvironmentRevisionDetails": {
         "properties": {
+          "base": {
+            "$ref": "#/components/schemas/domino.environments.api.EnvironmentRevision",
+            "nullable": true
+          },
           "canRevertTo": {
             "type": "boolean"
           },
@@ -7771,6 +8393,24 @@
         },
         "required": [
           "status"
+        ]
+      },
+      "domino.environments.api.EnvironmentTemplateMetadata": {
+        "properties": {
+          "revisionId": {
+            "type": "string"
+          },
+          "templateId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "templateId",
+          "revisionId"
         ]
       },
       "domino.environments.api.EnvironmentWorkspaceToolDefinition": {
@@ -7861,6 +8501,10 @@
           },
           "skipFirstBuild": {
             "type": "boolean"
+          },
+          "templateMetadata": {
+            "$ref": "#/components/schemas/domino.environments.api.EnvironmentTemplateMetadata",
+            "nullable": true
           },
           "visibility": {
             "enum": [
@@ -8038,6 +8682,17 @@
           "requireSubdomain"
         ]
       },
+      "domino.environments.api.RebuildEnvironmentRevision": {
+        "properties": {
+          "revisionId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "revisionId"
+        ]
+      },
       "domino.environments.api.RevisionOverview": {
         "properties": {
           "availableTools": {
@@ -8093,7 +8748,7 @@
       "domino.environments.api.RevisionSummary": {
         "properties": {
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "id": {
@@ -8566,8 +9221,7 @@
       "domino.featurestore.api.FeatureViewDto": {
         "properties": {
           "addedBy": {
-            "additionalProperties": true,
-            "type": "object"
+            "$ref": "#/components/schemas/StringStringMap"
           },
           "author": {
             "nullable": true,
@@ -8827,6 +9481,16 @@
           "commentContent"
         ]
       },
+      "domino.files.interface.Author": {
+        "properties": {
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "username"
+        ]
+      },
       "domino.files.interface.BranchInfo": {
         "properties": {
           "branchName": {
@@ -8854,7 +9518,7 @@
             "$ref": "#/components/schemas/domino.files.interface.CommentedBy"
           },
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -8970,6 +9634,51 @@
           "sourceType"
         ]
       },
+      "domino.files.interface.CommitSummaryForFilepath": {
+        "properties": {
+          "allCommitsForPath": {
+            "items": {
+              "$ref": "#/components/schemas/domino.files.interface.CommitInfo"
+            },
+            "type": "array"
+          },
+          "lastCommitOfFile": {
+            "$ref": "#/components/schemas/domino.files.interface.CommitInfo",
+            "nullable": true
+          },
+          "requestedOrNewestCommit": {
+            "$ref": "#/components/schemas/domino.files.interface.CommitInfo"
+          }
+        },
+        "required": [
+          "requestedOrNewestCommit",
+          "allCommitsForPath"
+        ]
+      },
+      "domino.files.interface.CredentialMappings": {
+        "properties": {
+          "credentialId": {
+            "nullable": true,
+            "type": "string"
+          },
+          "repoId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "repoId"
+        ]
+      },
+      "domino.files.interface.DefaultValues": {
+        "properties": {
+          "newName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "newName"
+        ]
+      },
       "domino.files.interface.DeletePropsDto": {
         "properties": {}
       },
@@ -9028,6 +9737,543 @@
           "value"
         ]
       },
+      "domino.files.interface.FileViewTemplateDto": {
+        "properties": {
+          "canEdit": {
+            "type": "boolean"
+          },
+          "canStartRun": {
+            "type": "boolean"
+          },
+          "commitSummaryForFilepath": {
+            "$ref": "#/components/schemas/domino.files.interface.CommitSummaryForFilepath"
+          },
+          "enableDaskClusters": {
+            "type": "boolean"
+          },
+          "enableRayClusters": {
+            "type": "boolean"
+          },
+          "enableReadWriteDatasets": {
+            "type": "boolean"
+          },
+          "enableSparkClusters": {
+            "type": "boolean"
+          },
+          "externalDataVolumesEnabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "commitSummaryForFilepath",
+          "externalDataVolumesEnabled",
+          "enableReadWriteDatasets",
+          "enableSparkClusters",
+          "enableRayClusters",
+          "enableDaskClusters",
+          "canStartRun",
+          "canEdit"
+        ]
+      },
+      "domino.files.interface.FilesBrowseSettingsDto": {
+        "properties": {
+          "allowFolderDownloads": {
+            "type": "boolean"
+          },
+          "maxUploadFileSizeInMegabytes": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "maxUploadFilesCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "allowFolderDownloads",
+          "maxUploadFilesCount",
+          "maxUploadFileSizeInMegabytes"
+        ]
+      },
+      "domino.files.interface.FilesPermissionsDto": {
+        "properties": {
+          "canBrowseReadFiles": {
+            "type": "boolean"
+          },
+          "canChangeProjectSettings": {
+            "type": "boolean"
+          },
+          "canEdit": {
+            "type": "boolean"
+          },
+          "canFullDelete": {
+            "type": "boolean"
+          },
+          "canListProject": {
+            "type": "boolean"
+          },
+          "canRun": {
+            "type": "boolean"
+          },
+          "globalUseFileStorage": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "globalUseFileStorage",
+          "canRun",
+          "canEdit",
+          "canBrowseReadFiles",
+          "canListProject",
+          "canFullDelete",
+          "canChangeProjectSettings"
+        ]
+      },
+      "domino.files.interface.GitCredentials": {
+        "properties": {
+          "domain": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "gitServiceProvider": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "protocol": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "domain",
+          "fingerprint",
+          "gitServiceProvider",
+          "protocol"
+        ]
+      },
+      "domino.files.interface.GitRepo": {
+        "properties": {
+          "domain": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "refLabel": {
+            "type": "string"
+          },
+          "refType": {
+            "type": "string"
+          },
+          "repoName": {
+            "type": "string"
+          },
+          "serviceProvider": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "location",
+          "repoName",
+          "domain",
+          "uri",
+          "refLabel",
+          "refType",
+          "serviceProvider"
+        ]
+      },
+      "domino.files.interface.ProjectCodeBrowseCommitDto": {
+        "properties": {
+          "commitsNonEmpty": {
+            "type": "boolean"
+          },
+          "commitsRunLink": {
+            "type": "string"
+          },
+          "headCommitCreatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "headCommitId": {
+            "type": "string"
+          },
+          "projectSizeBytes": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "runNumberForCommit": {
+            "type": "string"
+          },
+          "selectedRevision": {
+            "$ref": "#/components/schemas/domino.files.interface.RevisionShape"
+          },
+          "thisCommitId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "commitsNonEmpty",
+          "thisCommitId",
+          "headCommitId",
+          "headCommitCreatedAt",
+          "projectSizeBytes",
+          "runNumberForCommit",
+          "commitsRunLink",
+          "selectedRevision"
+        ]
+      },
+      "domino.files.interface.ProjectCodeBrowseDto": {
+        "properties": {
+          "allCredentialMappings": {
+            "items": {
+              "$ref": "#/components/schemas/domino.files.interface.CredentialMappings"
+            },
+            "type": "array"
+          },
+          "areReferencesCustomizable": {
+            "type": "boolean"
+          },
+          "commitSettings": {
+            "$ref": "#/components/schemas/domino.files.interface.ProjectCodeBrowseCommitDto"
+          },
+          "csrfToken": {
+            "nullable": true,
+            "type": "string"
+          },
+          "downloadCLIPageEndpoint": {
+            "type": "string"
+          },
+          "enableReadWriteDatasets": {
+            "type": "boolean"
+          },
+          "fileSettings": {
+            "$ref": "#/components/schemas/domino.files.interface.FilesBrowseSettingsDto"
+          },
+          "gitCredentials": {
+            "items": {
+              "$ref": "#/components/schemas/domino.files.interface.GitCredentials"
+            },
+            "type": "array"
+          },
+          "importedProjects": {
+            "items": {
+              "$ref": "#/components/schemas/domino.files.interface.ProjectImportsDto"
+            },
+            "type": "array"
+          },
+          "permissions": {
+            "$ref": "#/components/schemas/domino.files.interface.FilesPermissionsDto"
+          },
+          "previousDirectoryUrl": {
+            "type": "string"
+          },
+          "projectImportsIsEmpty": {
+            "type": "boolean"
+          },
+          "projectSettings": {
+            "$ref": "#/components/schemas/domino.files.interface.ProjectCodeBrowseProjectDto"
+          },
+          "relativeBreadcrumbData": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "runTaggingEnabled": {
+            "type": "boolean"
+          },
+          "showUploadComponentOnStart": {
+            "type": "boolean"
+          },
+          "suggestDatasets": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "projectImportsIsEmpty",
+          "importedProjects",
+          "runTaggingEnabled",
+          "showUploadComponentOnStart",
+          "suggestDatasets",
+          "relativeBreadcrumbData",
+          "downloadCLIPageEndpoint",
+          "areReferencesCustomizable",
+          "allCredentialMappings",
+          "gitCredentials",
+          "enableReadWriteDatasets",
+          "permissions",
+          "commitSettings",
+          "projectSettings",
+          "fileSettings",
+          "previousDirectoryUrl"
+        ]
+      },
+      "domino.files.interface.ProjectCodeBrowseProjectDto": {
+        "properties": {
+          "areDataProjectsEnabled": {
+            "type": "boolean"
+          },
+          "isAnalyticProject": {
+            "type": "boolean"
+          },
+          "isGitBasedProject": {
+            "type": "boolean"
+          },
+          "noRepos": {
+            "type": "boolean"
+          },
+          "projectId": {
+            "type": "string"
+          },
+          "projectType": {
+            "type": "string"
+          },
+          "projectVisibility": {
+            "type": "string"
+          },
+          "repositories": {
+            "items": {
+              "$ref": "#/components/schemas/domino.files.interface.GitRepo"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "projectId",
+          "projectVisibility",
+          "projectType",
+          "isGitBasedProject",
+          "areDataProjectsEnabled",
+          "isAnalyticProject",
+          "noRepos",
+          "repositories"
+        ]
+      },
+      "domino.files.interface.ProjectCodeCreateEditDto": {
+        "properties": {
+          "atHeadCommit": {
+            "type": "boolean"
+          },
+          "content": {
+            "type": "string"
+          },
+          "currentCommitId": {
+            "type": "string"
+          },
+          "defaultValues": {
+            "$ref": "#/components/schemas/domino.files.interface.DefaultValues"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "isDefaultAppSh": {
+            "type": "boolean"
+          },
+          "oldPath": {
+            "type": "string"
+          },
+          "relativeBreadCrumbs": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "showSaveAndRun": {
+            "type": "boolean"
+          },
+          "status": {
+            "enum": [
+              "Active",
+              "Deleted",
+              "Large",
+              "New"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "atHeadCommit",
+          "content",
+          "currentCommitId",
+          "defaultValues",
+          "filename",
+          "isDefaultAppSh",
+          "oldPath",
+          "relativeBreadCrumbs",
+          "showSaveAndRun",
+          "status"
+        ]
+      },
+      "domino.files.interface.ProjectCodeSharedViewDto": {
+        "properties": {
+          "availableRevisions": {
+            "items": {
+              "$ref": "#/components/schemas/domino.files.interface.RevisionShape"
+            },
+            "type": "array"
+          },
+          "commitId": {
+            "type": "string"
+          },
+          "commitsRunLink": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "isCommentPreviewEnabled": {
+            "type": "boolean"
+          },
+          "projectId": {
+            "type": "string"
+          },
+          "relativeBreadCrumbs": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "runNumberForCommit": {
+            "type": "string"
+          },
+          "selectedRevision": {
+            "$ref": "#/components/schemas/domino.files.interface.RevisionShape"
+          }
+        },
+        "required": [
+          "availableRevisions",
+          "commitId",
+          "commitsRunLink",
+          "filename",
+          "isCommentPreviewEnabled",
+          "projectId",
+          "relativeBreadCrumbs",
+          "runNumberForCommit",
+          "selectedRevision"
+        ]
+      },
+      "domino.files.interface.ProjectCodeViewDto": {
+        "properties": {
+          "action": {
+            "type": "string"
+          },
+          "availableRevisions": {
+            "items": {
+              "$ref": "#/components/schemas/domino.files.interface.RevisionShape"
+            },
+            "type": "array"
+          },
+          "commitsRunLink": {
+            "type": "string"
+          },
+          "csrfToken": {
+            "nullable": true,
+            "type": "string"
+          },
+          "fileViewTemplate": {
+            "$ref": "#/components/schemas/domino.files.interface.FileViewTemplateDto"
+          },
+          "filename": {
+            "type": "string"
+          },
+          "headRevisionDirectoryLink": {
+            "type": "string"
+          },
+          "isCommentPreviewEnabled": {
+            "type": "boolean"
+          },
+          "isFileRunnableAsApp": {
+            "type": "boolean"
+          },
+          "isFileRunnableFromView": {
+            "type": "boolean"
+          },
+          "projectId": {
+            "type": "string"
+          },
+          "projectVisibility": {
+            "type": "string"
+          },
+          "relativeBreadCrumbs": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "revertFileEndpoint": {
+            "type": "string"
+          },
+          "runNumberForCommit": {
+            "type": "string"
+          },
+          "selectedRevision": {
+            "$ref": "#/components/schemas/domino.files.interface.RevisionShape"
+          }
+        },
+        "required": [
+          "projectId",
+          "projectVisibility",
+          "fileViewTemplate",
+          "filename",
+          "relativeBreadCrumbs",
+          "revertFileEndpoint",
+          "isFileRunnableAsApp",
+          "isFileRunnableFromView",
+          "headRevisionDirectoryLink",
+          "isCommentPreviewEnabled",
+          "action",
+          "runNumberForCommit",
+          "commitsRunLink",
+          "selectedRevision",
+          "availableRevisions"
+        ]
+      },
+      "domino.files.interface.ProjectDirectoryForTable": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "sizeInBytes": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "path",
+          "sizeInBytes",
+          "name"
+        ]
+      },
       "domino.files.interface.ProjectFile": {
         "properties": {
           "goalIds": {
@@ -9060,6 +10306,189 @@
           "goalIds"
         ]
       },
+      "domino.files.interface.ProjectFileForTable": {
+        "properties": {
+          "goalIds": {
+            "items": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "isFileLaunchableAsNotebook": {
+            "type": "boolean"
+          },
+          "isFileRunnableAsApp": {
+            "type": "boolean"
+          },
+          "isFileRunnableFromView": {
+            "type": "boolean"
+          },
+          "key": {
+            "type": "string"
+          },
+          "lastModified": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "quotedFilePath": {
+            "type": "string"
+          },
+          "size": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "sizeLabel": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "lastModified",
+          "size",
+          "key",
+          "goalIds",
+          "name",
+          "quotedFilePath",
+          "sizeLabel",
+          "isFileLaunchableAsNotebook",
+          "isFileRunnableFromView",
+          "isFileRunnableAsApp"
+        ]
+      },
+      "domino.files.interface.ProjectGitBrowseDto": {
+        "properties": {
+          "allCredentialMappings": {
+            "items": {
+              "$ref": "#/components/schemas/domino.files.interface.CredentialMappings"
+            },
+            "type": "array"
+          },
+          "areReferencesCustomizable": {
+            "type": "boolean"
+          },
+          "csrfToken": {
+            "nullable": true,
+            "type": "string"
+          },
+          "gitCredentials": {
+            "items": {
+              "$ref": "#/components/schemas/domino.files.interface.GitCredentials"
+            },
+            "type": "array"
+          },
+          "noRepos": {
+            "type": "boolean"
+          },
+          "permissions": {
+            "$ref": "#/components/schemas/domino.files.interface.FilesPermissionsDto"
+          },
+          "projectId": {
+            "type": "string"
+          },
+          "projectMainRepositoryDefaultRefType": {
+            "nullable": true,
+            "type": "string"
+          },
+          "projectMainRepositoryDefaultRefValue": {
+            "nullable": true,
+            "type": "string"
+          },
+          "projectMainRepositoryId": {
+            "nullable": true,
+            "type": "string"
+          },
+          "projectMainRepositoryServiceProvider": {
+            "nullable": true,
+            "type": "string"
+          },
+          "projectMainRepositoryUri": {
+            "nullable": true,
+            "type": "string"
+          },
+          "projectType": {
+            "type": "string"
+          },
+          "repositories": {
+            "items": {
+              "$ref": "#/components/schemas/domino.files.interface.RepositoryViewModelDto"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "areReferencesCustomizable",
+          "repositories",
+          "projectId",
+          "noRepos",
+          "projectType",
+          "gitCredentials",
+          "allCredentialMappings",
+          "permissions"
+        ]
+      },
+      "domino.files.interface.ProjectImportsDto": {
+        "properties": {
+          "availableReleases": {
+            "items": {
+              "$ref": "#/components/schemas/domino.files.interface.ProjectReleaseDto"
+            },
+            "type": "array"
+          },
+          "filesAvailable": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "isArchived": {
+            "type": "boolean"
+          },
+          "mountPath": {
+            "type": "string"
+          },
+          "ownerUsername": {
+            "type": "string"
+          },
+          "packageAvailable": {
+            "type": "boolean"
+          },
+          "projectName": {
+            "type": "string"
+          },
+          "projects": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "variablesAvailable": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "projectName",
+          "ownerUsername",
+          "variablesAvailable",
+          "isActive",
+          "isArchived",
+          "filesAvailable",
+          "packageAvailable",
+          "projects",
+          "availableReleases",
+          "mountPath"
+        ]
+      },
       "domino.files.interface.ProjectReadmeFile": {
         "properties": {
           "path": {
@@ -9068,6 +10497,111 @@
         },
         "required": [
           "path"
+        ]
+      },
+      "domino.files.interface.ProjectReleaseDto": {
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          },
+          "isSelected": {
+            "type": "boolean"
+          },
+          "releaseId": {
+            "type": "string"
+          },
+          "runHeading": {
+            "type": "string"
+          },
+          "runNumber": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "releaseId",
+          "runNumber",
+          "runHeading",
+          "createdAt",
+          "isSelected"
+        ]
+      },
+      "domino.files.interface.RepositoryViewModelDto": {
+        "properties": {
+          "domain": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "refLabel": {
+            "type": "string"
+          },
+          "refType": {
+            "type": "string"
+          },
+          "repoName": {
+            "type": "string"
+          },
+          "serviceProvider": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "location",
+          "repoName",
+          "uri",
+          "domain",
+          "refLabel",
+          "refType",
+          "serviceProvider"
+        ]
+      },
+      "domino.files.interface.RevisionShape": {
+        "properties": {
+          "author": {
+            "$ref": "#/components/schemas/domino.files.interface.Author"
+          },
+          "message": {
+            "type": "string"
+          },
+          "runId": {
+            "type": "string"
+          },
+          "runLink": {
+            "type": "string"
+          },
+          "runNumberStr": {
+            "type": "string"
+          },
+          "sha": {
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "sha",
+          "message",
+          "timestamp",
+          "url",
+          "author",
+          "runNumberStr",
+          "runLink"
         ]
       },
       "domino.files.web.ArchiveFileComment": {
@@ -9224,6 +10758,28 @@
           "commitId",
           "projectId",
           "goalId"
+        ]
+      },
+      "domino.files.web.SaveFile": {
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "creatingNewFile": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "mustRun": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "content"
         ]
       },
       "domino.files.web.UnlinkFileFromGoal": {
@@ -10011,15 +11567,16 @@
       },
       "domino.hardwaretier.api.HardwareTierDto": {
         "properties": {
-          "allowSharedMemoryToExceedDefault": {
-            "type": "boolean"
-          },
           "availabilityZones": {
             "items": {
               "type": "string"
             },
             "nullable": true,
             "type": "array"
+          },
+          "capacity": {
+            "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierCapacity",
+            "nullable": true
           },
           "centsPerMinute": {
             "format": "double",
@@ -10038,15 +11595,6 @@
             "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierComputeClusterRestrictionsDto",
             "nullable": true
           },
-          "cores": {
-            "format": "double",
-            "type": "number"
-          },
-          "coresLimit": {
-            "format": "double",
-            "nullable": true,
-            "type": "number"
-          },
           "creationTime": {
             "format": "date-time",
             "type": "string"
@@ -10059,46 +11607,19 @@
             "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierGpuConfigurationDto",
             "nullable": true
           },
+          "hwtFlags": {
+            "$ref": "#/components/schemas/domino.hardwaretier.api.HwtFlags"
+          },
+          "hwtResources": {
+            "$ref": "#/components/schemas/domino.hardwaretier.api.HwtResources"
+          },
           "id": {
             "type": "string"
-          },
-          "isAllowedDuringTrial": {
-            "type": "boolean"
-          },
-          "isArchived": {
-            "type": "boolean"
-          },
-          "isDataAnalystTier": {
-            "type": "boolean"
-          },
-          "isDefault": {
-            "type": "boolean"
-          },
-          "isDefaultForModelApi": {
-            "nullable": true,
-            "type": "boolean"
-          },
-          "isFree": {
-            "type": "boolean"
-          },
-          "isGlobal": {
-            "type": "boolean"
-          },
-          "isModelApiTier": {
-            "nullable": true,
-            "type": "boolean"
-          },
-          "isVisible": {
-            "type": "boolean"
           },
           "maxSimultaneousExecutions": {
             "format": "int32",
             "nullable": true,
             "type": "integer"
-          },
-          "memory": {
-            "format": "double",
-            "type": "number"
           },
           "metadata": {
             "additionalProperties": {
@@ -10120,15 +11641,6 @@
           "podCustomization": {
             "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierPodCustomizationDto"
           },
-          "runMemoryLimit": {
-            "$ref": "#/components/schemas/domino.common.executor.run.RunMemoryLimitDto",
-            "nullable": true
-          },
-          "sharedMemoryLimitGiB": {
-            "format": "double",
-            "nullable": true,
-            "type": "number"
-          },
           "tags": {
             "items": {
               "type": "string"
@@ -10144,20 +11656,12 @@
         "required": [
           "id",
           "name",
-          "cores",
-          "memory",
-          "allowSharedMemoryToExceedDefault",
-          "isDefault",
+          "hwtResources",
+          "hwtFlags",
           "centsPerMinute",
-          "isFree",
-          "isAllowedDuringTrial",
-          "isVisible",
-          "isGlobal",
-          "isArchived",
           "creationTime",
           "updateTime",
           "podCustomization",
-          "isDataAnalystTier",
           "metadata"
         ]
       },
@@ -10168,10 +11672,14 @@
               "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierDto"
             },
             "type": "array"
+          },
+          "isDataAnalystEnabled": {
+            "type": "boolean"
           }
         },
         "required": [
-          "hardwareTiers"
+          "hardwareTiers",
+          "isDataAnalystEnabled"
         ]
       },
       "domino.hardwaretier.api.HardwareTierGpuConfigurationDto": {
@@ -10308,55 +11816,12 @@
           "dataPlane"
         ]
       },
-      "domino.hardwaretier.api.NewHardwareTierDto": {
+      "domino.hardwaretier.api.HwtFlags": {
         "properties": {
-          "allowSharedMemoryToExceedDefault": {
+          "isAllowedDuringTrial": {
             "type": "boolean"
           },
-          "availabilityZones": {
-            "items": {
-              "type": "string"
-            },
-            "nullable": true,
-            "type": "array"
-          },
-          "centsPerMinute": {
-            "format": "double",
-            "type": "number"
-          },
-          "clusterType": {
-            "enum": [
-              "ClassicOnPremises",
-              "ClassicAWS",
-              "Kubernetes"
-            ],
-            "nullable": true,
-            "type": "string"
-          },
-          "computeClusterRestrictions": {
-            "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierComputeClusterRestrictionsDto"
-          },
-          "cores": {
-            "format": "double",
-            "type": "number"
-          },
-          "coresLimit": {
-            "format": "double",
-            "nullable": true,
-            "type": "number"
-          },
-          "dataPlaneId": {
-            "nullable": true,
-            "type": "string"
-          },
-          "gpuConfiguration": {
-            "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierGpuConfigurationDto",
-            "nullable": true
-          },
-          "id": {
-            "type": "string"
-          },
-          "isAllowedDuringTrial": {
+          "isArchived": {
             "type": "boolean"
           },
           "isDataAnalystTier": {
@@ -10381,21 +11846,108 @@
           },
           "isVisible": {
             "type": "boolean"
+          }
+        },
+        "required": [
+          "isDefault",
+          "isVisible",
+          "isGlobal",
+          "isArchived",
+          "isFree",
+          "isDataAnalystTier",
+          "isAllowedDuringTrial"
+        ]
+      },
+      "domino.hardwaretier.api.HwtResources": {
+        "properties": {
+          "allowSharedMemoryToExceedDefault": {
+            "type": "boolean"
+          },
+          "cores": {
+            "format": "double",
+            "type": "number"
+          },
+          "coresLimit": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/Information"
+          },
+          "memoryLimit": {
+            "$ref": "#/components/schemas/Information",
+            "nullable": true
+          },
+          "memorySwapLimit": {
+            "$ref": "#/components/schemas/Information",
+            "nullable": true
+          },
+          "sharedMemoryLimit": {
+            "$ref": "#/components/schemas/Information",
+            "nullable": true
+          }
+        },
+        "required": [
+          "cores",
+          "memory",
+          "allowSharedMemoryToExceedDefault"
+        ]
+      },
+      "domino.hardwaretier.api.NewHardwareTierDto": {
+        "properties": {
+          "availabilityZones": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "centsPerMinute": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "clusterType": {
+            "enum": [
+              "ClassicOnPremises",
+              "ClassicAWS",
+              "Kubernetes"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "computeClusterRestrictions": {
+            "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierComputeClusterRestrictionsDto",
+            "nullable": true
+          },
+          "dataPlaneId": {
+            "nullable": true,
+            "type": "string"
+          },
+          "gpuConfiguration": {
+            "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierGpuConfigurationDto",
+            "nullable": true
+          },
+          "hwtFlags": {
+            "$ref": "#/components/schemas/domino.hardwaretier.api.NewHwtFlags",
+            "nullable": true
+          },
+          "hwtResources": {
+            "$ref": "#/components/schemas/domino.hardwaretier.api.HwtResources"
+          },
+          "id": {
+            "type": "string"
           },
           "maxSimultaneousExecutions": {
             "format": "int32",
             "nullable": true,
             "type": "integer"
           },
-          "memory": {
-            "format": "double",
-            "type": "number"
-          },
           "name": {
             "type": "string"
           },
           "nodePool": {
-            "nullable": true,
             "type": "string"
           },
           "overprovisioning": {
@@ -10403,16 +11955,8 @@
             "nullable": true
           },
           "podCustomization": {
-            "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierPodCustomizationDto"
-          },
-          "runMemoryLimit": {
-            "$ref": "#/components/schemas/domino.common.executor.run.RunMemoryLimitDto",
+            "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierPodCustomizationDto",
             "nullable": true
-          },
-          "sharedMemoryLimitGiB": {
-            "format": "double",
-            "nullable": true,
-            "type": "number"
           },
           "tags": {
             "items": {
@@ -10425,19 +11969,41 @@
         "required": [
           "id",
           "name",
-          "cores",
-          "memory",
-          "allowSharedMemoryToExceedDefault",
-          "isDefault",
-          "centsPerMinute",
-          "isFree",
-          "isAllowedDuringTrial",
-          "isVisible",
-          "isGlobal",
-          "computeClusterRestrictions",
-          "podCustomization",
-          "isDataAnalystTier"
+          "hwtResources",
+          "nodePool"
         ]
+      },
+      "domino.hardwaretier.api.NewHwtFlags": {
+        "properties": {
+          "isAllowedDuringTrial": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "isDataAnalystTier": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "isDefault": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "isDefaultForModelApi": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "isGlobal": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "isModelApiTier": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "isVisible": {
+            "nullable": true,
+            "type": "boolean"
+          }
+        }
       },
       "domino.jobs.interface.ArtifactsInfoDto": {
         "properties": {
@@ -10556,7 +12122,7 @@
             "$ref": "#/components/schemas/domino.jobs.interface.Commenter"
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -11210,7 +12776,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -11423,7 +12989,7 @@
             "type": "integer"
           },
           "jobStartTime": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "jobStatus": {
@@ -11481,7 +13047,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -11621,7 +13187,7 @@
             "type": "string"
           },
           "lastModified": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "size": {
@@ -11640,17 +13206,17 @@
       "domino.jobs.interface.StageTime": {
         "properties": {
           "completedTime": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
           "runStartTime": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
           "submissionTime": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -11675,7 +13241,7 @@
       "domino.jobs.interface.TagApplication": {
         "properties": {
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -11731,6 +13297,17 @@
           "commentId"
         ]
       },
+      "domino.jobs.web.ArchiveJobRequest": {
+        "properties": {
+          "jobId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "jobId"
+        ]
+      },
       "domino.jobs.web.CreateComment": {
         "properties": {
           "comment": {
@@ -11770,29 +13347,9 @@
           "jobStatusChangeEvent"
         ]
       },
-      "domino.jobs.web.JobOperationRequest": {
-        "properties": {
-          "jobId": {
-            "pattern": "^[0-9a-f]{24}$",
-            "type": "string"
-          },
-          "projectId": {
-            "pattern": "^[0-9a-f]{24}$",
-            "type": "string"
-          }
-        },
-        "required": [
-          "projectId",
-          "jobId"
-        ]
-      },
       "domino.jobs.web.JobRestartOperationRequest": {
         "properties": {
           "jobId": {
-            "pattern": "^[0-9a-f]{24}$",
-            "type": "string"
-          },
-          "projectId": {
             "pattern": "^[0-9a-f]{24}$",
             "type": "string"
           },
@@ -11801,7 +13358,6 @@
           }
         },
         "required": [
-          "projectId",
           "jobId",
           "shouldUseOriginalInputCommit"
         ]
@@ -11831,7 +13387,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -11852,14 +13408,9 @@
           "jobId": {
             "pattern": "^[0-9a-f]{24}$",
             "type": "string"
-          },
-          "projectId": {
-            "pattern": "^[0-9a-f]{24}$",
-            "type": "string"
           }
         },
         "required": [
-          "projectId",
           "jobId",
           "commitResults"
         ]
@@ -11885,7 +13436,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -11903,14 +13454,9 @@
           "goalId": {
             "pattern": "^[0-9a-f]{24}$",
             "type": "string"
-          },
-          "projectId": {
-            "pattern": "^[0-9a-f]{24}$",
-            "type": "string"
           }
         },
         "required": [
-          "projectId",
           "goalId"
         ]
       },
@@ -12019,14 +13565,9 @@
           "goalId": {
             "pattern": "^[0-9a-f]{24}$",
             "type": "string"
-          },
-          "projectId": {
-            "pattern": "^[0-9a-f]{24}$",
-            "type": "string"
           }
         },
         "required": [
-          "projectId",
           "goalId"
         ]
       },
@@ -12387,7 +13928,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -12456,7 +13997,7 @@
             "type": "boolean"
           },
           "lastModified": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "name": {
@@ -12506,7 +14047,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -12657,7 +14198,7 @@
       "domino.modelmanager.api.ModelExport": {
         "properties": {
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "id": {
@@ -12761,7 +14302,7 @@
             "type": "string"
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "exportId": {
@@ -12999,7 +14540,7 @@
             "type": "string"
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -13149,44 +14690,6 @@
           "envRevisionNumber",
           "requestedUserId",
           "status"
-        ]
-      },
-      "domino.modelmanager.api.ModelsForUIApiResponse": {
-        "properties": {
-          "currentItemCount": {
-            "format": "int32",
-            "type": "integer"
-          },
-          "itemsPerPage": {
-            "format": "int32",
-            "type": "integer"
-          },
-          "modelAccess": {
-            "additionalProperties": true,
-            "type": "object"
-          },
-          "models": {
-            "items": {
-              "$ref": "#/components/schemas/domino.modelmanager.api.Model"
-            },
-            "type": "array"
-          },
-          "startIndex": {
-            "format": "int32",
-            "type": "integer"
-          },
-          "totalItems": {
-            "format": "int32",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "currentItemCount",
-          "startIndex",
-          "itemsPerPage",
-          "totalItems",
-          "models",
-          "modelAccess"
         ]
       },
       "domino.modelmanager.api.SnowflakeExport": {
@@ -14085,7 +15588,7 @@
           "Critical",
           "Default"
         ],
-        "type": "string"
+        "type": "String"
       },
       "domino.notifications.Timeframe": {
         "properties": {
@@ -14693,10 +16196,6 @@
             "type": "string"
           },
           "canonicalName": {
-            "nullable": true,
-            "type": "string"
-          },
-          "docsRoot": {
             "nullable": true,
             "type": "string"
           },
@@ -15824,7 +17323,7 @@
             "type": "array"
           },
           "updatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -15869,7 +17368,7 @@
             "type": "string"
           },
           "updatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -15886,7 +17385,7 @@
       "domino.projectManagement.api.FullSyncStatus": {
         "properties": {
           "lastSyncInitiatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "syncStatus": {
@@ -15940,7 +17439,7 @@
             "nullable": true
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "dominoEntity": {
@@ -15951,7 +17450,7 @@
             "$ref": "#/components/schemas/domino.projectManagement.api.PmId"
           },
           "updatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -16100,7 +17599,7 @@
             "type": "string"
           },
           "updatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -16345,14 +17844,9 @@
           "goalId": {
             "pattern": "^[0-9a-f]{24}$",
             "type": "string"
-          },
-          "projectId": {
-            "pattern": "^[0-9a-f]{24}$",
-            "type": "string"
           }
         },
         "required": [
-          "projectId",
           "goalId"
         ]
       },
@@ -16401,14 +17895,9 @@
           "goalId": {
             "pattern": "^[0-9a-f]{24}$",
             "type": "string"
-          },
-          "projectId": {
-            "pattern": "^[0-9a-f]{24}$",
-            "type": "string"
           }
         },
         "required": [
-          "projectId",
           "goalId"
         ]
       },
@@ -16443,6 +17932,23 @@
           "stageName"
         ]
       },
+      "domino.projects.api.AddManyCollaborators": {
+        "properties": {
+          "collaboratorUsernameOrEmails": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "welcomeMessage": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "collaboratorUsernameOrEmails"
+        ]
+      },
       "domino.projects.api.AssetPortfolioElement": {
         "properties": {
           "assetId": {
@@ -16461,7 +17967,7 @@
             "type": "string"
           },
           "lastUpdatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
@@ -16580,7 +18086,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "usageCount": {
@@ -16616,7 +18122,7 @@
             "$ref": "#/components/schemas/domino.projects.api.ProjectStakeholder"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -16704,11 +18210,11 @@
             "$ref": "#/components/schemas/domino.projects.api.Commenter"
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "updatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -16804,6 +18310,35 @@
           "credentialId"
         ]
       },
+      "domino.projects.api.CreateReviewRequest": {
+        "properties": {
+          "authorId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "fromProjectId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "intoProjectId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "authorId",
+          "title",
+          "summary",
+          "intoProjectId",
+          "fromProjectId"
+        ]
+      },
       "domino.projects.api.DefaultOnDemandSparkClusterPropertiesSpec": {
         "properties": {
           "computeEnvironmentId": {
@@ -16860,6 +18395,32 @@
           "maximumExecutionSlotsPerUser"
         ]
       },
+      "domino.projects.api.DependencyTemplate": {
+        "properties": {
+          "kind": {
+            "enum": [
+              "Project",
+              "Environment"
+            ],
+            "type": "string"
+          },
+          "revisionId": {
+            "type": "string"
+          },
+          "templateId": {
+            "type": "string"
+          },
+          "templateName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "templateName",
+          "templateId",
+          "revisionId",
+          "kind"
+        ]
+      },
       "domino.projects.api.EntityLink": {
         "properties": {
           "createdBy": {
@@ -16880,7 +18441,7 @@
             "$ref": "#/components/schemas/domino.projects.api.EntityLinkMetadata"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -16931,6 +18492,10 @@
               "$ref": "#/components/schemas/ComputeClusterType"
             },
             "type": "array"
+          },
+          "templateMetadata": {
+            "$ref": "#/components/schemas/domino.environments.api.EnvironmentTemplateMetadata",
+            "nullable": true
           },
           "visibility": {
             "enum": [
@@ -17359,7 +18924,7 @@
             "type": "string"
           },
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -17384,17 +18949,17 @@
             "type": "boolean"
           },
           "lastDescriptionUpdatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
           "lastTitleUpdatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
           "lastUpdatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
@@ -17434,7 +18999,7 @@
             "type": "boolean"
           },
           "lastStageUpdatedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "stage": {
@@ -17494,6 +19059,13 @@
             "nullable": true,
             "type": "string"
           },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.DependencyTemplate"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "description": {
             "nullable": true,
             "type": "string"
@@ -17546,12 +19118,23 @@
             "nullable": true,
             "type": "array"
           },
+          "projectSettings": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateProjectSettings",
+            "nullable": true
+          },
           "recommended": {
             "nullable": true,
             "type": "boolean"
           },
           "revisionId": {
             "type": "string"
+          },
+          "supportedDominoVersions": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "templateId": {
             "type": "string"
@@ -17630,6 +19213,13 @@
           "revisionId": {
             "type": "string"
           },
+          "supportedDominoVersions": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "templateId": {
             "type": "string"
           },
@@ -17676,6 +19266,24 @@
           "name",
           "owner",
           "isArchived"
+        ]
+      },
+      "domino.projects.api.ProjectKerberosConfig": {
+        "properties": {
+          "kerberosMode": {
+            "type": "string"
+          },
+          "keytabFileName": {
+            "nullable": true,
+            "type": "string"
+          },
+          "principal": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "kerberosMode"
         ]
       },
       "domino.projects.api.ProjectOwnerInfo": {
@@ -17734,7 +19342,7 @@
             "type": "number"
           },
           "createdOn": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "duration": {
@@ -17742,7 +19350,7 @@
             "type": "integer"
           },
           "lastActivity": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
@@ -17893,10 +19501,89 @@
           "statuStats"
         ]
       },
+      "domino.projects.api.ProjectResultsBranchSettingChoices": {
+        "properties": {
+          "branch": {
+            "enum": [
+              "Isolated",
+              "Main"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "branch"
+        ]
+      },
+      "domino.projects.api.ProjectSettingsExport": {
+        "properties": {
+          "exportEnvironmentVariables": {
+            "type": "boolean"
+          },
+          "exportFiles": {
+            "type": "boolean"
+          },
+          "exportPackageType": {
+            "enum": [
+              "Python",
+              "R"
+            ],
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "exportEnvironmentVariables",
+          "exportFiles"
+        ]
+      },
+      "domino.projects.api.ProjectSparkConfig": {
+        "properties": {
+          "freeFormConfig": {
+            "nullable": true,
+            "type": "string"
+          },
+          "hadoopUserName": {
+            "nullable": true,
+            "type": "string"
+          },
+          "hostnameMappings": {
+            "nullable": true,
+            "type": "string"
+          },
+          "masterHost": {
+            "nullable": true,
+            "type": "string"
+          },
+          "masterPort": {
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "onDemandFreeFormConfig": {
+            "nullable": true,
+            "type": "string"
+          },
+          "sparkLegacyProxiable": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "sparkMode": {
+            "type": "string"
+          },
+          "yarnFreeFormConfig": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "sparkMode"
+        ]
+      },
       "domino.projects.api.ProjectStage": {
         "properties": {
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -18130,23 +19817,48 @@
           "templateId"
         ]
       },
-      "domino.projects.api.ProjectTemplateEnvironment": {
+      "domino.projects.api.ProjectTemplateEnvRevDetails": {
         "properties": {
-          "id": {
+          "environmentId": {
             "pattern": "^[0-9a-f]{24}$",
             "type": "string"
           },
           "link": {
             "type": "string"
           },
+          "revisionNumber": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "environmentId",
+          "revisionNumber",
+          "link"
+        ]
+      },
+      "domino.projects.api.ProjectTemplateEnvironment": {
+        "properties": {
           "name": {
+            "type": "string"
+          },
+          "revisionDetails": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateEnvRevDetails",
+            "nullable": true
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "domino.projects.api.ProjectTemplateGoalStages": {
+        "properties": {
+          "stageName": {
             "type": "string"
           }
         },
         "required": [
-          "id",
-          "name",
-          "link"
+          "stageName"
         ]
       },
       "domino.projects.api.ProjectTemplateGoals": {
@@ -18187,6 +19899,21 @@
           "link"
         ]
       },
+      "domino.projects.api.ProjectTemplateProjectSettings": {
+        "properties": {
+          "projectGoalStages": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateGoalStages"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "requireCommitMessage": {
+            "nullable": true,
+            "type": "boolean"
+          }
+        }
+      },
       "domino.projects.api.ProxyConfig": {
         "properties": {
           "internalPath": {
@@ -18204,6 +19931,33 @@
           "internalPath",
           "port",
           "rewrite"
+        ]
+      },
+      "domino.projects.api.ResolveReviewRequest": {
+        "properties": {
+          "fromCommitId": {
+            "type": "string"
+          },
+          "intoCommitId": {
+            "type": "string"
+          },
+          "resolution": {
+            "enum": [
+              "Open",
+              "Accepted",
+              "Rejected"
+            ],
+            "type": "string"
+          },
+          "resolutionDecisions": {
+            "$ref": "#/components/schemas/StringStringMap"
+          }
+        },
+        "required": [
+          "resolution",
+          "fromCommitId",
+          "intoCommitId",
+          "resolutionDecisions"
         ]
       },
       "domino.projects.api.RevisionOverview": {
@@ -18260,6 +20014,9 @@
             "nullable": true,
             "type": "boolean"
           },
+          "name": {
+            "type": "string"
+          },
           "supportedClusters": {
             "items": {
               "$ref": "#/components/schemas/ComputeClusterType"
@@ -18273,6 +20030,7 @@
         },
         "required": [
           "id",
+          "name",
           "supportedClusters"
         ]
       },
@@ -18371,6 +20129,55 @@
         "required": [
           "name",
           "projectCount"
+        ]
+      },
+      "domino.projects.api.UpdateProjectAnonymousRunExecutionSettings": {
+        "properties": {
+          "allowPublicRunExecution": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "allowPublicRunExecution"
+        ]
+      },
+      "domino.projects.api.UpdateProjectName": {
+        "properties": {
+          "newName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "newName"
+        ]
+      },
+      "domino.projects.api.UpdateProjectNotificationPreference": {
+        "properties": {
+          "collaboratorId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "notificationPreference": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "collaboratorId",
+          "notificationPreference"
+        ]
+      },
+      "domino.projects.api.UpdateReviewRequest": {
+        "properties": {
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "summary"
         ]
       },
       "domino.projects.api.UseableProjectEnvironmentsDTO": {
@@ -18609,6 +20416,16 @@
           "name"
         ]
       },
+      "domino.projects.api.repositories.responses.CreateBranchApiResponse": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
       "domino.projects.api.repositories.responses.GetBranchesApiResponse": {
         "properties": {
           "currentItemCount": {
@@ -18672,10 +20489,33 @@
           "summary"
         ]
       },
-      "domino.projects.api.repositories.responses.GitApiResponseWrapper": {
+      "domino.projects.api.repositories.responses.GetRepoFilesApiResponse": {
+        "properties": {
+          "files": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "files"
+        ]
+      },
+      "domino.projects.api.repositories.responses.GitApiResponseWrapper[domino.gitproviders.api.GetOwnersApiResponse]": {
         "properties": {
           "data": {
             "$ref": "#/components/schemas/domino.gitproviders.api.GetOwnersApiResponse"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "domino.projects.api.repositories.responses.GitApiResponseWrapper[domino.projects.api.repositories.responses.GetRepoFilesApiResponse]": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/domino.projects.api.repositories.responses.GetRepoFilesApiResponse"
           }
         },
         "required": [
@@ -18717,7 +20557,7 @@
       "domino.projects.api.repositories.responses.browse.CommitAuthorDTO": {
         "properties": {
           "date": {
-            "type": "string"
+            "type": "date"
           },
           "name": {
             "type": "string"
@@ -18821,7 +20661,7 @@
       "domino.projects.web.AddBlockedAtComment": {
         "properties": {
           "blockedAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "comment": {
@@ -20289,7 +22129,7 @@
       "domino.server.projectreleases.ProjectReleaseDto": {
         "properties": {
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -21855,6 +23695,10 @@
             "pattern": "^[0-9a-f]{24}$",
             "type": "string"
           },
+          "pushOnly": {
+            "nullable": true,
+            "type": "boolean"
+          },
           "repos": {
             "items": {
               "$ref": "#/components/schemas/domino.workspace.api.git.CommitRepo"
@@ -22357,7 +24201,7 @@
             "$ref": "#/components/schemas/domino.workspaces.api.Commenter"
           },
           "created": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -22724,7 +24568,7 @@
             "type": "integer"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -22840,7 +24684,7 @@
             "type": "string"
           },
           "lastModified": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "size": {
@@ -22859,17 +24703,17 @@
       "domino.workspaces.api.StageTime": {
         "properties": {
           "completedTime": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
           "startTime": {
-            "format": "int64",
+            "format": "epoch",
             "nullable": true,
             "type": "integer"
           },
           "submissionTime": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -23127,7 +24971,7 @@
             "type": "number"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           }
         },
@@ -23270,7 +25114,7 @@
       "domino.workspaces.api.WorkspaceTag": {
         "properties": {
           "createdAt": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "createdBy": {
@@ -23558,7 +25402,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "workspaceId": {
@@ -23596,7 +25440,7 @@
             "type": "string"
           },
           "timestamp": {
-            "format": "int64",
+            "format": "epoch",
             "type": "integer"
           },
           "workspaceId": {
@@ -23613,7 +25457,19 @@
           "mem",
           "timestamp"
         ]
-      }
+      },
+      "StringIntMap": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "integer"
+        }
+      },
+      "StringStringMap": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "integer"
+        }
+      }      
     },
     "securitySchemes": {
       "BearerAuthentication": {
@@ -23668,6 +25524,106 @@
         "summary": "retrieves git providers list",
         "tags": [
           "Git Credentials"
+        ]
+      }
+    },
+    "/accounts/idpid/{idpid}/environmentvariables": {
+      "post": {
+        "operationId": "setUserEnvironmentVariable",
+        "parameters": [
+          {
+            "description": "Idp ID of the user for which the environment variable is set",
+            "in": "path",
+            "name": "idpid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.common.models.EnvironmentVariable"
+              }
+            }
+          },
+          "description": "Environment Variable",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "sets an Environment Variable for the user",
+        "tags": [
+          "Users"
+        ]
+      }
+    },
+    "/accounts/idpid/{idpid}/environmentvariables/{variableName}": {
+      "delete": {
+        "operationId": "unsetUserEnvironmentVariable",
+        "parameters": [
+          {
+            "description": "Idp ID of the user for which the environment variable is unset",
+            "in": "path",
+            "name": "idpid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The name of the environment variable to unset",
+            "in": "path",
+            "name": "variableName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "unsets an Environment Variable for the user",
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -23858,7 +25814,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -23869,7 +25825,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -23930,7 +25886,7 @@
     },
     "/activity/metadata": {
       "get": {
-        "operationId": "getActivityMetadata",
+        "operationId": "notFound",
         "responses": {
           "200": {
             "content": {
@@ -23981,7 +25937,7 @@
             "required": true,
             "schema": {
               "format": "int32",
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -24000,7 +25956,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -24011,7 +25967,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           }
         ],
@@ -24042,6 +25998,43 @@
         "summary": "Gets the activity stream for a registered model",
         "tags": [
           "Activity"
+        ]
+      }
+    },
+    "/admin/adminMenu": {
+      "get": {
+        "operationId": "getAdminMenu",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.admin.web.MenuItemDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Gets the Admin menu items customized for the caller.",
+        "tags": [
+          "Admin"
         ]
       }
     },
@@ -24578,7 +26571,6 @@
     "/admin/notifications/admin": {
       "post": {
         "operationId": "createNotificationSuperUser",
-        "responses": {},
         "tags": [
           "adminnotifications"
         ]
@@ -24702,6 +26694,256 @@
         ]
       }
     },
+    "/admin/user-management/users": {
+      "get": {
+        "operationId": "getUsers",
+        "parameters": [
+          {
+            "description": "How many users from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of users to fetch. Defaults to 50.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.admin.usermanagement.api.UsersResponse"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get users.",
+        "tags": [
+          "UserManagement"
+        ]
+      }
+    },
+    "/admin/user-management/users-with-usage": {
+      "get": {
+        "operationId": "getUsersWithUsage",
+        "parameters": [
+          {
+            "description": "How many users from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max number of users to fetch. Defaults to 50.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.admin.usermanagement.api.UsersWithUsageResponse"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Gets users and their user usage reports.",
+        "tags": [
+          "UserManagement"
+        ]
+      }
+    },
+    "/admin/user-management/users/reports/aggregate-user-activity-report": {
+      "get": {
+        "operationId": "aggregateUserActivityReport",
+        "parameters": [
+          {
+            "description": "IdpId of the target user.",
+            "in": "path",
+            "name": "targetUserIdpId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.admin.usermanagement.api.AggregateUserActivityReport"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Gets aggregate user activity report",
+        "tags": [
+          "UserManagement"
+        ]
+      }
+    },
+    "/admin/user-management/users/{targetUserIdpId}": {
+      "patch": {
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "description": "IdpId of user to update.",
+            "in": "path",
+            "name": "targetUserIdpId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.admin.usermanagement.api.UpdateUserRequest"
+              }
+            }
+          },
+          "description": "Fields to update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.admin.usermanagement.api.AdminUserManagementUser"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Update a user.",
+        "tags": [
+          "UserManagement"
+        ]
+      }
+    },
+    "/admin/user-management/users/{targetUserIdpId}/password-reset": {
+      "post": {
+        "operationId": "passwordReset",
+        "parameters": [
+          {
+            "description": "IdpId of the target user.",
+            "in": "path",
+            "name": "targetUserIdpId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Reset a user's password.",
+        "tags": [
+          "UserManagement"
+        ]
+      }
+    },
     "/admin/whitelabel/configurations": {
       "get": {
         "operationId": "getWhiteLabelConfigurations",
@@ -24785,6 +27027,333 @@
         ]
       }
     },
+    "/code/browseCode": {
+      "get": {
+        "operationId": "browseCode",
+        "parameters": [
+          {
+            "description": "Name of project owner",
+            "in": "query",
+            "name": "ownerUsername",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of project",
+            "in": "query",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path to file from root",
+            "in": "query",
+            "name": "pathString",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "CommitId of directory",
+            "in": "query",
+            "name": "commitIdStr",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Current branch that's not main",
+            "in": "query",
+            "name": "branchName",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.files.interface.ProjectCodeBrowseDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Retrieves directory for browse files table",
+        "tags": [
+          "Code"
+        ]
+      }
+    },
+    "/code/gitBrowse": {
+      "get": {
+        "operationId": "gitBrowse",
+        "parameters": [
+          {
+            "description": "Name of project owner",
+            "in": "query",
+            "name": "ownerUsername",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of project",
+            "in": "query",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "CommitId of directory",
+            "in": "query",
+            "name": "commitIdStr",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.files.interface.ProjectGitBrowseDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Retrieves directory for browse files table",
+        "tags": [
+          "Code"
+        ]
+      }
+    },
+    "/code/saveCode": {
+      "post": {
+        "operationId": "saveCode",
+        "parameters": [
+          {
+            "description": "Name of project owner",
+            "in": "query",
+            "name": "ownerUsername",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of project",
+            "in": "query",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.files.web.SaveFile"
+              }
+            }
+          },
+          "description": "What file to save",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Save and save or run file",
+        "tags": [
+          "Code"
+        ]
+      }
+    },
+    "/code/sharedViewCode": {
+      "get": {
+        "operationId": "sharedViewCode",
+        "parameters": [
+          {
+            "description": "Name of project owner",
+            "in": "query",
+            "name": "ownerUsername",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of project",
+            "in": "query",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path to file from root",
+            "in": "query",
+            "name": "pathString",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "CommitId of file",
+            "in": "query",
+            "name": "commitIdHolder",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.files.interface.ProjectCodeSharedViewDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Retrieves file to view",
+        "tags": [
+          "Code"
+        ]
+      }
+    },
+    "/code/viewCode": {
+      "get": {
+        "operationId": "viewCode",
+        "parameters": [
+          {
+            "description": "Name of project owner",
+            "in": "query",
+            "name": "ownerUsername",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of project",
+            "in": "query",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path to file from root",
+            "in": "query",
+            "name": "pathString",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "CommitId of file",
+            "in": "query",
+            "name": "commitIdHolder",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.files.interface.ProjectCodeViewDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Retrieves file to view",
+        "tags": [
+          "Code"
+        ]
+      }
+    },
     "/computecluster/{executionId}/computeClusterFileSync": {
       "post": {
         "operationId": "startComputeClusterFileSync",
@@ -24797,7 +27366,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -24842,7 +27412,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -24887,7 +27458,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -25062,10 +27634,9 @@
     "/controlCenter/utilization/kubecostDeployed": {
       "get": {
         "operationId": "getKubecostLiveness",
-        "responses": {},
         "summary": "this endpoint will be temporarily used to discover if Kubecost is installed and will be removed if we retire the current cost& compute page",
         "tags": [
-          "Control Center"
+          "controlcenter"
         ]
       }
     },
@@ -26749,10 +29320,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.dataplane.DataPlaneDto"
-                  },
-                  "type": "array"
+                  "$ref": "#/components/schemas/domino.dataplane.DataPlaneDto"
                 }
               }
             },
@@ -26850,10 +29418,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.dataplane.DataPlaneDto"
-                  },
-                  "type": "array"
+                  "$ref": "#/components/schemas/domino.dataplane.DataPlaneDto"
                 }
               }
             },
@@ -27063,7 +29628,7 @@
     "/dataplanes/targetVersion": {
       "get": {
         "operationId": "getTargetDataPlaneVersion",
-        "parameters": [],
+        "parameters": null,
         "responses": {
           "200": {
             "content": {
@@ -27133,7 +29698,7 @@
     },
     "/datasetUi/collections": {
       "post": {
-        "operationId": "createDatasetCollection",
+        "operationId": "createDataset",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -27291,7 +29856,7 @@
     },
     "/datasetUi/collections/{datasetId}": {
       "post": {
-        "operationId": "updateDatasetUi",
+        "operationId": "updateDataset",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -27441,7 +30006,7 @@
     },
     "/datasetUi/collections/{datasetId}/snapshot/file": {
       "post": {
-        "operationId": "uploadSnapshotFileUi",
+        "operationId": "uploadSnapshotFile",
         "parameters": [
           {
             "in": "path",
@@ -27594,13 +30159,7 @@
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.dataset.api.DatasetSnapshotDto"
-                }
-              }
-            },
+            "$ref": "#/components/schemas/domino.dataset.api.DatasetSnapshotDto",
             "description": "the new snapshot"
           },
           "400": {
@@ -27804,7 +30363,7 @@
     },
     "/datasetUi/collections/{datasetId}/snapshots": {
       "get": {
-        "operationId": "getSnapshotsUi",
+        "operationId": "getSnapshots",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -28358,7 +30917,7 @@
     },
     "/datasetUi/project/{projectId}/canAddDataset": {
       "get": {
-        "operationId": "canAddDatasetUi",
+        "operationId": "canAddDataset",
         "parameters": [
           {
             "description": "Project identifier",
@@ -28788,7 +31347,7 @@
     },
     "/datasetUi/{snapshotId}": {
       "get": {
-        "operationId": "getSnapshotUi",
+        "operationId": "getSnapshot",
         "parameters": [
           {
             "description": "Id of the snapshot",
@@ -29034,6 +31593,7 @@
           "200": {
             "content": {
               "application/json": {
+                "required": false,
                 "schema": {
                   "type": "number"
                 }
@@ -29623,7 +32183,7 @@
         "operationId": "renameFileOrDirectory",
         "parameters": [
           {
-            "description": "Dataset Id",
+            "description": "Dataset ID",
             "in": "path",
             "name": "datasetId",
             "required": true,
@@ -29727,7 +32287,7 @@
         "operationId": "updateDatasetStatus",
         "parameters": [
           {
-            "description": "Dataset Id",
+            "description": "Dataset ID",
             "in": "path",
             "name": "datasetId",
             "required": true,
@@ -29780,7 +32340,7 @@
     },
     "/datasetrw/dataset/{datasetId}/tag": {
       "post": {
-        "operationId": "addDatasetTag",
+        "operationId": "addTag",
         "parameters": [
           {
             "description": "Dataset ID",
@@ -29836,7 +32396,7 @@
     },
     "/datasetrw/dataset/{datasetId}/tag/{tagName}": {
       "delete": {
-        "operationId": "removeDatasetTag",
+        "operationId": "removeTag",
         "parameters": [
           {
             "description": "Dataset ID",
@@ -30107,7 +32667,7 @@
     },
     "/datasetrw/datasets/limit/{projectId}": {
       "post": {
-        "operationId": "setDatasetLimitOverride",
+        "operationId": "setLimitOverride",
         "parameters": [
           {
             "description": "Id of the project",
@@ -30270,7 +32830,7 @@
         "operationId": "getDataset",
         "parameters": [
           {
-            "description": "Dataset Id",
+            "description": "Dataset ID",
             "in": "path",
             "name": "datasetId",
             "required": true,
@@ -30458,7 +33018,7 @@
     },
     "/datasetrw/datasets/{datasetId}/snapshot/file/cancel/{uploadKey}": {
       "get": {
-        "operationId": "cancelDatasetSnapshotUpload",
+        "operationId": "cancelSnapshotUpload",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -30505,9 +33065,10 @@
     },
     "/datasetrw/datasets/{datasetId}/snapshot/file/end/{uploadKey}": {
       "get": {
-        "operationId": "endDatasetSnapshotUpload",
+        "operationId": "endSnapshotUpload",
         "parameters": [
           {
+            "description": "Dataset ID",
             "in": "path",
             "name": "datasetId",
             "required": true,
@@ -30517,10 +33078,21 @@
             }
           },
           {
+            "description": "identifier for upload directory",
             "in": "path",
             "name": "uploadKey",
             "required": true,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "target path of files to upload relative to root of dataset",
+            "in": "query",
+            "name": "targetRelativePath",
+            "required": false,
+            "schema": {
+              "nullable": true,
               "type": "string"
             }
           }
@@ -30549,7 +33121,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Indicates the successful completion of the files upload in the UI",
+        "summary": "Checks for destination consistency and if consistent, moves uploaded files to specified dataset directory.",
         "tags": [
           "DatasetRw"
         ]
@@ -30557,7 +33129,7 @@
     },
     "/datasetrw/datasets/{datasetId}/snapshot/file/start": {
       "post": {
-        "operationId": "startDatasetSnapshotUpload",
+        "operationId": "startSnapshotUpload",
         "parameters": [
           {
             "description": "Id of the collection of datasets",
@@ -30696,7 +33268,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -30739,9 +33311,8 @@
             "description": "subPath to get files at",
             "in": "query",
             "name": "path",
-            "required": false,
+            "required": true,
             "schema": {
-              "nullable": true,
               "type": "string"
             }
           }
@@ -30796,7 +33367,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -30859,7 +33430,7 @@
     },
     "/datasetrw/marked-snapshots": {
       "delete": {
-        "operationId": "deleteDatasetMarkedSnapshots",
+        "operationId": "deleteMarkedSnapshots",
         "responses": {
           "200": {
             "content": {
@@ -31161,7 +33732,7 @@
         "operationId": "getActiveSnapshotByNumber",
         "parameters": [
           {
-            "description": "Dataset Id",
+            "description": "Dataset ID",
             "in": "query",
             "name": "datasetId",
             "required": true,
@@ -31349,7 +33920,7 @@
     },
     "/datasetrw/snapshot/upload/{uploadKey}": {
       "get": {
-        "operationId": "getDatasetSnapshotUploadSession",
+        "operationId": "getSnapshotUploadSession",
         "parameters": [
           {
             "in": "path",
@@ -31392,7 +33963,7 @@
     },
     "/datasetrw/snapshot/{snapshotId}": {
       "delete": {
-        "operationId": "deleteDatasetSnapshot",
+        "operationId": "deleteSnapshot",
         "parameters": [
           {
             "description": "Snapshot ID",
@@ -31478,7 +34049,7 @@
         ]
       },
       "put": {
-        "operationId": "updateDatasetSnapshotStatus",
+        "operationId": "updateSnapshotStatus",
         "parameters": [
           {
             "description": "Id of the dataset snapshot to be updated",
@@ -31672,7 +34243,7 @@
         "operationId": "getCopyEstimate",
         "parameters": [
           {
-            "description": "Snapshot Id",
+            "description": "Snapshot ID",
             "in": "path",
             "name": "snapshotId",
             "required": true,
@@ -31729,7 +34300,7 @@
         "operationId": "getCopyProgress",
         "parameters": [
           {
-            "description": "Snapshot Id",
+            "description": "Snapshot ID",
             "in": "path",
             "name": "snapshotId",
             "required": true,
@@ -32081,8 +34652,7 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "format": "binary",
-                  "type": "string"
+                  "type": "binary"
                 }
               }
             },
@@ -32260,7 +34830,7 @@
     },
     "/datasetrw/snapshots/summary/{datasetId}": {
       "get": {
-        "operationId": "getDatasetSnapshotSummaries",
+        "operationId": "getSnapshotSummaries",
         "parameters": [
           {
             "description": "Dataset ID",
@@ -32376,6 +34946,7 @@
           "200": {
             "content": {
               "application/json": {
+                "required": true,
                 "schema": {
                   "items": {
                     "$ref": "#/components/schemas/domino.datasetrw.api.DatasetStorageUsageDto"
@@ -32423,6 +34994,7 @@
           "200": {
             "content": {
               "application/json": {
+                "required": false,
                 "schema": {
                   "$ref": "#/components/schemas/domino.datasetrw.api.DatasetStorageUsageDto"
                 }
@@ -32591,7 +35163,7 @@
         ]
       },
       "post": {
-        "operationId": "createDataSource",
+        "operationId": "create",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -32705,8 +35277,7 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "format": "binary",
-                  "type": "string"
+                  "type": "binary"
                 }
               }
             },
@@ -32764,8 +35335,7 @@
             "content": {
               "application/jsonl": {
                 "schema": {
-                  "format": "binary",
-                  "type": "string"
+                  "type": "binary"
                 }
               }
             },
@@ -32838,7 +35408,7 @@
     },
     "/datasource/auths/all": {
       "get": {
-        "operationId": "getDataSourceAuthConfigs",
+        "operationId": "getAuthConfigs",
         "parameters": [],
         "responses": {
           "200": {
@@ -33050,7 +35620,7 @@
     },
     "/datasource/full": {
       "get": {
-        "operationId": "getDataSourceFullCredentials",
+        "operationId": "getFullCredentials",
         "parameters": [
           {
             "description": "registered data source id",
@@ -33220,6 +35790,16 @@
             "name": "username",
             "required": true,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "id of run in which the data source is being retrieved",
+            "in": "query",
+            "name": "runId",
+            "required": false,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
               "type": "string"
             }
           }
@@ -34451,7 +37031,7 @@
     },
     "/datasource/{dataSourceId}/projects/{projectId}": {
       "delete": {
-        "operationId": "removeProjectFromDataSource",
+        "operationId": "removeProject",
         "parameters": [
           {
             "description": "Data source Id",
@@ -34504,7 +37084,7 @@
         ]
       },
       "post": {
-        "operationId": "addProjectToDataSource",
+        "operationId": "addProject",
         "parameters": [
           {
             "description": "Data source Id",
@@ -34667,7 +37247,7 @@
     },
     "/datasource/{dataSourceId}/users": {
       "delete": {
-        "operationId": "removeUsersFromDataSource",
+        "operationId": "removeUsers",
         "parameters": [
           {
             "description": "Data source Id",
@@ -34723,7 +37303,7 @@
         ]
       },
       "post": {
-        "operationId": "addUsersToDataSource",
+        "operationId": "addUsers",
         "parameters": [
           {
             "description": "Data source Id",
@@ -34779,7 +37359,7 @@
         ]
       },
       "put": {
-        "operationId": "updateUsersForDataSource",
+        "operationId": "updateUsers",
         "parameters": [
           {
             "description": "data source id",
@@ -35001,6 +37581,51 @@
         ]
       }
     },
+    "/environments/rebuildrevision": {
+      "post": {
+        "operationId": "rebuildEnvironmentRevision",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.environments.api.RebuildEnvironmentRevision"
+              }
+            }
+          },
+          "description": "JSON object with environment data to rebuild the environment",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.environments.api.EnvironmentDetails"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Rebuild environment",
+        "tags": [
+          "Environments"
+        ]
+      }
+    },
     "/environments/self": {
       "get": {
         "operationId": "getCurrentUserEnvironments",
@@ -35067,17 +37692,6 @@
         "operationId": "setDefaultEnvironment",
         "parameters": [],
         "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/domino.environments.api.SetDeployDefaultEnvRequest"
-              }
-            }
-          },
-          "description": "The ID of the environment to set as the deployment default",
-          "required": true
-        },
-        "responses": {
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
@@ -35089,7 +37703,16 @@
           },
           "500": {
             "$ref": "#/components/responses/InternalError"
-          }
+          },
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.environments.api.SetDeployDefaultEnvRequest"
+              }
+            }
+          },
+          "description": "The ID of the environment to set as the deployment default",
+          "required": true
         },
         "summary": "Set default environment",
         "tags": [
@@ -35338,6 +37961,57 @@
       }
     },
     "/environments/{environmentId}/environmentRevision/{environmentRevisionId}": {
+      "get": {
+        "operationId": "getEnvironmentRevisionOverview",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "environmentId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "environmentRevisionId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.environments.api.RevisionOverview"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get an environment revision's overview",
+        "tags": [
+          "Environments"
+        ]
+      },
       "patch": {
         "operationId": "updateEnvironmentRevisionIsRestricted",
         "parameters": [
@@ -35692,7 +38366,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -35703,7 +38377,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -35714,7 +38388,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -35826,7 +38500,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -35837,7 +38511,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -35848,7 +38522,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -37005,6 +39679,154 @@
         ]
       }
     },
+    "/files/browseDirectories": {
+      "get": {
+        "operationId": "listDirectoriesAtPath",
+        "parameters": [
+          {
+            "description": "username of project owner",
+            "in": "query",
+            "name": "ownerUsername",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "name of project",
+            "in": "query",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "file path to query",
+            "in": "query",
+            "name": "filePath",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "branch to list commits for",
+            "in": "query",
+            "name": "commitId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.files.interface.ProjectDirectoryForTable"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get all directories for a commit at a path in a project",
+        "tags": [
+          "Files"
+        ]
+      }
+    },
+    "/files/browseFiles": {
+      "get": {
+        "operationId": "listFilesAtPath",
+        "parameters": [
+          {
+            "description": "username of project owner",
+            "in": "query",
+            "name": "ownerUsername",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "name of project",
+            "in": "query",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "file path to query",
+            "in": "query",
+            "name": "filePath",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "branch to list commits for",
+            "in": "query",
+            "name": "commitId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.files.interface.ProjectFileForTable"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get all files for a commit at a path in a project",
+        "tags": [
+          "Files"
+        ]
+      }
+    },
     "/files/comment": {
       "get": {
         "operationId": "getFileCommentThread",
@@ -37152,6 +39974,149 @@
         "summary": "Archive a File Comment",
         "tags": [
           "Files"
+        ]
+      }
+    },
+    "/files/createCode": {
+      "get": {
+        "operationId": "getCreateInfo",
+        "parameters": [
+          {
+            "description": "Name of project owner",
+            "in": "query",
+            "name": "ownerUsername",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of project",
+            "in": "query",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path to file from root",
+            "in": "query",
+            "name": "pathString",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.files.interface.ProjectCodeCreateEditDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get values to build FE for create file",
+        "tags": [
+          "Code"
+        ]
+      }
+    },
+    "/files/editCode": {
+      "get": {
+        "operationId": "getEditInfo",
+        "parameters": [
+          {
+            "description": "Name of project owner",
+            "in": "query",
+            "name": "ownerUsername",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of project",
+            "in": "query",
+            "name": "projectName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path to file from root",
+            "in": "query",
+            "name": "pathString",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Commit id of file",
+            "in": "query",
+            "name": "commitIdHolder",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Default page",
+            "in": "query",
+            "name": "defaultTemplate",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.files.interface.ProjectCodeCreateEditDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get values to build FE for edit file",
+        "tags": [
+          "Code"
         ]
       }
     },
@@ -37739,7 +40704,7 @@
     },
     "/frontend/snippets": {
       "get": {
-        "operationId": "listFrontendSnippets",
+        "operationId": "list",
         "parameters": [],
         "responses": {
           "200": {
@@ -37770,7 +40735,7 @@
     },
     "/gateway/projects": {
       "get": {
-        "operationId": "listProjects",
+        "operationId": "list",
         "parameters": [
           {
             "description": "The relationship between the current user and the projects to be returned",
@@ -38012,7 +40977,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           }
         ],
@@ -38080,7 +41045,7 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -38273,7 +41238,7 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
+              "$ref": "#/components/schemas/domino.common.DominoId"
             }
           }
         ],
@@ -38282,7 +41247,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/domino.projects.api.repositories.responses.GitApiResponseWrapper"
+                  "$ref": "#/components/schemas/domino.projects.api.repositories.responses.GitApiResponseWrapper[domino.gitproviders.api.GetOwnersApiResponse]"
                 }
               }
             },
@@ -38334,7 +41299,7 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
+              "$ref": "#/components/schemas/domino.common.DominoId"
             }
           },
           {
@@ -38572,6 +41537,50 @@
         ]
       }
     },
+    "/hardwareTier/update": {
+      "put": {
+        "operationId": "updateHardwareTier",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Update a hardware tier",
+        "tags": [
+          "Hardware Tier"
+        ]
+      }
+    },
     "/hardwareTier/withCapacity/{hardwareTierId}": {
       "get": {
         "operationId": "getHardwareTierWithCapacity",
@@ -38590,7 +41599,7 @@
             "required": false,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
+              "type": "domino.common.DominoId"
             }
           }
         ],
@@ -38645,7 +41654,7 @@
             "required": false,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
+              "type": "domino.common.DominoId"
             }
           }
         ],
@@ -38812,7 +41821,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "type": "string"
           },
           {
             "description": "Id of the project",
@@ -38822,7 +41832,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "description": "Command parameters that needs to be passed to the job",
@@ -38831,7 +41842,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "type": "string"
           }
         ],
         "responses": {
@@ -38866,7 +41878,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/domino.jobs.web.JobOperationRequest"
+                "$ref": "#/components/schemas/domino.jobs.web.ArchiveJobRequest"
               }
             }
           },
@@ -38905,7 +41917,7 @@
     },
     "/jobs/events": {
       "get": {
-        "operationId": "getJobEvents",
+        "operationId": "notFound",
         "responses": {
           "200": {
             "content": {
@@ -38939,7 +41951,7 @@
     },
     "/jobs/getStatus/values": {
       "get": {
-        "operationId": "getJobStatusValues",
+        "operationId": "getJobStatuses",
         "parameters": [],
         "responses": {
           "200": {
@@ -38988,14 +42000,10 @@
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.jobs.interface.ArtifactsInfoDto"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "$ref": "#/components/schemas/domino.jobs.interface.ArtifactsInfoDto"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -39090,14 +42098,10 @@
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.jobs.interface.CodeInfoDto"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "$ref": "#/components/schemas/domino.jobs.interface.CodeInfoDto"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -39626,7 +42630,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -39671,7 +42676,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -39706,7 +42712,7 @@
     },
     "/jobs/{jobId}/computeClusterFileSyncStatus": {
       "get": {
-        "operationId": "getJobComputeClusterFileSyncStatus",
+        "operationId": "getComputeClusterFileSyncStatus",
         "parameters": [
           {
             "description": "ID of the job",
@@ -39716,7 +42722,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -39751,7 +42758,7 @@
     },
     "/jobs/{jobId}/computeClusterStatus": {
       "get": {
-        "operationId": "getJobComputeClusterStatus",
+        "operationId": "getComputeClusterStatus",
         "parameters": [
           {
             "description": "ID of the job",
@@ -39761,7 +42768,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -39869,7 +42877,7 @@
     },
     "/jobs/{jobId}/linkJobToGoal": {
       "post": {
-        "operationId": "linkSingleJobToGoal",
+        "operationId": "linkJobToGoal",
         "parameters": [
           {
             "in": "path",
@@ -40594,15 +43602,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "description": "Id of the Project",
-            "in": "query",
-            "name": "projectId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -40650,7 +43649,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "description": "Type of the cluster to get settings for",
@@ -40999,6 +43999,106 @@
         ]
       }
     },
+    "/mlflow/execution/{executionId}/provenanceCheckpoints": {
+      "get": {
+        "operationId": "getProvenanceCheckpointsForExecution",
+        "parameters": [
+          {
+            "description": "Id of execution to retrieve checkpoints for for",
+            "in": "path",
+            "name": "executionId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip.  Can not be negative.\n",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The size of the page to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "A column name to sort over - createdAt, dfsBranch, executionStart, mainGitBranch - default is 'createdAt'.",
+            "in": "query",
+            "name": "sortBy",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/domino.provenance.api.SortableFields.Value",
+              "enum": [
+                "createdAt",
+                "dfsBranch",
+                "executionStart",
+                "mainGitBranch"
+              ],
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "order of sort.  default is 'desc'.",
+            "in": "query",
+            "name": "sortOrder",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.provenance.api.ProvenanceCheckpointDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get provenance checkpoints created by an execution. Used to link mlflow runs to the source commit that created them",
+        "tags": [
+          "MLFlow"
+        ]
+      }
+    },
     "/mlflow/previewFileConfig": {
       "get": {
         "operationId": "getPreviewFileConfig",
@@ -41142,7 +44242,7 @@
     },
     "/modelManager/buildModelImage": {
       "post": {
-        "operationId": "buildManagerModelImage",
+        "operationId": "buildModelImage",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -41157,14 +44257,10 @@
         },
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.modelmanager.api.ModelBuild"
-                }
-              }
-            },
-            "description": "Request accepted, building of model API image continues offline"
+            "description": "Request accepted, building of model API image continues offline",
+            "schema": {
+              "$ref": "#/components/schemas/domino.modelmanager.api.ModelBuild"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -41202,14 +44298,10 @@
         },
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.modelmanager.web.ExportVersionStatusWithoutModelResponse"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of image continues offline"
+            "description": "Request accepted, exporting of image continues offline",
+            "schema": {
+              "$ref": "#/components/schemas/domino.modelmanager.web.ExportVersionStatusWithoutModelResponse"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -41266,14 +44358,10 @@
         },
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.modelmanager.api.ModelExportVersionStatus"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of model API image continues offline"
+            "description": "Request accepted, exporting of model API image continues offline",
+            "schema": {
+              "$ref": "#/components/schemas/domino.modelmanager.api.ModelExportVersionStatus"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -41336,7 +44424,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           }
         ],
@@ -41415,7 +44503,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           }
         ],
@@ -41484,7 +44572,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           }
         ],
@@ -41620,7 +44708,7 @@
             "schema": {
               "format": "int64",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -41799,7 +44887,7 @@
               "format": "int32",
               "minimum": 0,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -41811,7 +44899,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -41892,7 +44980,7 @@
               "format": "int32",
               "minimum": 0,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -41904,7 +44992,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -42100,15 +45188,11 @@
         "responses": {
           "200": {
             "description": "success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.modelmanager.api.responses.ModelPermissionForMonitoringApiResponse"
-                  },
-                  "type": "array"
-                }
-              }
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.api.responses.ModelPermissionForMonitoringApiResponse"
+              },
+              "type": "array"
             }
           },
           "400": {
@@ -42189,7 +45273,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -42201,7 +45285,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -42261,20 +45345,14 @@
             "schema": {
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           }
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.modelmanager.api.ModelsForUIApiResponse"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "type": "object"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -42312,14 +45390,10 @@
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.modelmanager.api.responses.ModelPermissionsForUIApiResponse"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "$ref": "#/components/schemas/domino.modelmanager.api.responses.ModelPermissionsForUIApiResponse"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -43261,10 +46335,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           },
           "500": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           }
         },
         "summary": "list top model product views for a given time range",
@@ -43570,7 +46644,7 @@
     },
     "/modelProducts/{modelProductId}/start": {
       "post": {
-        "operationId": "startModelProduct",
+        "operationId": "start",
         "parameters": [
           {
             "in": "path",
@@ -43624,7 +46698,7 @@
     },
     "/modelProducts/{modelProductId}/stop": {
       "post": {
-        "operationId": "stopModelProduct",
+        "operationId": "stop",
         "parameters": [
           {
             "description": "Domino id of the model product (app)",
@@ -43731,10 +46805,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           },
           "500": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           }
         },
         "summary": "get count of views on one model product for a given time range",
@@ -43787,10 +46861,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           },
           "500": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           }
         },
         "summary": "get count of views on one model product for a given time range",
@@ -43869,17 +46943,13 @@
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.common.modelproduct.AppVersionOverview"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.common.modelproduct.AppVersionOverview"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -43980,10 +47050,10 @@
             "description": "success"
           },
           "401": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           },
           "500": {
-            "$ref": "#/components/responses/ModelProductErrorResponse"
+            "$ref": "#/components/schemas/domino.nucleus.modelproduct.models.ModelProductError"
           }
         },
         "summary": "record a view on a model product",
@@ -44266,7 +47336,6 @@
             }
           }
         ],
-        "responses": {},
         "tags": [
           "photonRawData"
         ]
@@ -44401,13 +47470,6 @@
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
             }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -44485,13 +47547,6 @@
               "nullable": true,
               "type": "string"
             }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -44539,13 +47594,6 @@
             "in": "query",
             "name": "ticketId",
             "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
             "schema": {
               "type": "string"
             }
@@ -44617,13 +47665,6 @@
               "nullable": true,
               "type": "string"
             }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -44664,7 +47705,7 @@
     },
     "/projectManagement/goal/{goalId}": {
       "delete": {
-        "operationId": "deleteManageProjectGoal",
+        "operationId": "deleteProjectGoal",
         "parameters": [
           {
             "in": "path",
@@ -44672,13 +47713,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -44726,7 +47760,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -44774,7 +47809,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "description": "Domino id of user being assigned to the goal",
@@ -44784,7 +47820,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -44822,7 +47859,7 @@
     },
     "/projectManagement/goal/{goalId}/comment": {
       "post": {
-        "operationId": "addManageCommentOnGoal",
+        "operationId": "addCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -44830,13 +47867,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -44887,7 +47917,7 @@
     },
     "/projectManagement/goal/{goalId}/comment/list": {
       "get": {
-        "operationId": "getManageCommentsOnGoal",
+        "operationId": "getCommentsOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -44895,13 +47925,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -44951,7 +47974,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -45002,7 +48026,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "description": "Domino id of the project stage",
@@ -45012,14 +48037,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -45057,7 +48076,7 @@
     },
     "/projectManagement/goal/{goalId}/updateDescription": {
       "post": {
-        "operationId": "updateManageProjectGoalDescription",
+        "operationId": "updateProjectGoalDescription",
         "parameters": [
           {
             "in": "path",
@@ -45065,13 +48084,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -45122,7 +48134,7 @@
     },
     "/projectManagement/goal/{goalId}/updateTitle": {
       "post": {
-        "operationId": "updateManageProjectGoalTitle",
+        "operationId": "updateProjectGoalTitle",
         "parameters": [
           {
             "in": "path",
@@ -45130,13 +48142,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -45187,7 +48192,7 @@
     },
     "/projectManagement/goalComment/{threadId}/{commentId}": {
       "delete": {
-        "operationId": "archiveManageCommentOnGoal",
+        "operationId": "archiveCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -45204,13 +48209,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -45248,7 +48246,7 @@
         ]
       },
       "put": {
-        "operationId": "updateManageCommentOnGoal",
+        "operationId": "updateCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -45265,13 +48263,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -45322,7 +48313,7 @@
     },
     "/projectManagement/goalComment/{threadId}/{commentId}/canUpdate": {
       "get": {
-        "operationId": "canUpdateManageCommentOnGoal",
+        "operationId": "canUpdateCommentOnGoal",
         "parameters": [
           {
             "in": "path",
@@ -45339,13 +48330,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -45396,13 +48380,6 @@
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
             }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -45441,15 +48418,6 @@
     "/projectManagement/isUserAuthenticated": {
       "post": {
         "operationId": "isUserAuthenticated",
-        "parameters": [
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -45496,13 +48464,6 @@
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
             }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -45541,15 +48502,6 @@
     "/projectManagement/jiraBasicAuth": {
       "post": {
         "operationId": "jiraBasicAuth",
-        "parameters": [
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -45645,16 +48597,7 @@
     },
     "/projectManagement/linkFileToGoal": {
       "post": {
-        "operationId": "linkManageFileToGoalForProject",
-        "parameters": [
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "operationId": "linkFileToGoal",
         "requestBody": {
           "content": {
             "application/json": {
@@ -45702,15 +48645,6 @@
     "/projectManagement/moveProjectToStage": {
       "post": {
         "operationId": "moveProjectToStage",
-        "parameters": [
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -45757,7 +48691,7 @@
     },
     "/projectManagement/project/{projectId}/comment": {
       "post": {
-        "operationId": "addManageCommentOnProject",
+        "operationId": "addCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -45765,13 +48699,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -45822,7 +48749,7 @@
     },
     "/projectManagement/project/{projectId}/comment/list": {
       "get": {
-        "operationId": "getManageCommentsOnProject",
+        "operationId": "getCommentsOnProject",
         "parameters": [
           {
             "in": "path",
@@ -45830,13 +48757,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -45886,7 +48806,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -45927,7 +48848,7 @@
     },
     "/projectManagement/projectComment/{threadId}/{commentId}": {
       "delete": {
-        "operationId": "archiveManageCommentOnProject",
+        "operationId": "archiveCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -45944,13 +48865,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -45988,7 +48902,7 @@
         ]
       },
       "put": {
-        "operationId": "updateManageCommentOnProject",
+        "operationId": "updateCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -46005,13 +48919,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -46062,7 +48969,7 @@
     },
     "/projectManagement/projectComment/{threadId}/{commentId}/canUpdate": {
       "get": {
-        "operationId": "canUpdateManageCommentOnProject",
+        "operationId": "canUpdateCommentOnProject",
         "parameters": [
           {
             "in": "path",
@@ -46079,13 +48986,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -46161,16 +49061,7 @@
     },
     "/projectManagement/unlinkFileFromGoal": {
       "post": {
-        "operationId": "unlinkManageProjectFileFromGoal",
-        "parameters": [
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "operationId": "unlinkFileFromGoal",
         "requestBody": {
           "content": {
             "application/json": {
@@ -46264,13 +49155,6 @@
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
             }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "requestBody": {
@@ -46319,7 +49203,7 @@
     },
     "/projectManagement/{jobId}/unlinkJobFromGoal": {
       "post": {
-        "operationId": "unlinkManageJobFromGoal",
+        "operationId": "unlinkJobFromGoal",
         "parameters": [
           {
             "in": "path",
@@ -46327,13 +49211,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -46439,7 +49316,7 @@
     },
     "/projectManagement/{projectId}/createGoal": {
       "post": {
-        "operationId": "createManageProjectGoal",
+        "operationId": "createProjectGoal",
         "parameters": [
           {
             "in": "path",
@@ -46447,13 +49324,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -46569,7 +49439,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -46617,7 +49488,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -46668,7 +49540,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -46750,8 +49623,7 @@
         },
         "summary": "Get project goals",
         "tags": [
-          "ProjectManagement",
-          "Projects"
+          "ProjectManagement"
         ]
       },
       "post": {
@@ -46763,13 +49635,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -46842,7 +49707,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "in": "query",
@@ -46850,13 +49716,6 @@
             "required": true,
             "schema": {
               "type": "boolean"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -46893,6 +49752,66 @@
         ]
       }
     },
+    "/projectManagement/{projectId}/projectGoalStages": {
+      "get": {
+        "operationId": "getProjectGoalStages",
+        "parameters": [
+          {
+            "description": "Domino id of the project to get goal stages from",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "type": "domino.common.DominoId"
+          },
+          {
+            "description": "Include archived stages in the results",
+            "in": "query",
+            "name": "includeArchived",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            },
+            "type": "Boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.projects.api.ProjectStage"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get all project goal stages on a project.",
+        "tags": [
+          "ProjectManagement"
+        ]
+      }
+    },
     "/projectManagement/{projectId}/unlinkAndResetProject": {
       "post": {
         "operationId": "unlinkAndResetProject",
@@ -46905,7 +49824,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -46946,7 +49866,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "in": "query",
@@ -46954,13 +49875,6 @@
             "required": true,
             "schema": {
               "type": "boolean"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -47054,7 +49968,7 @@
     },
     "/projectManagement/{workspaceId}/linkWorkspaceToGoal": {
       "post": {
-        "operationId": "linkManageWorkspaceToGoal",
+        "operationId": "linkWorkspaceToGoal",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -47064,14 +49978,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
-              "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "requestBody": {
@@ -47120,7 +50028,7 @@
     },
     "/projectManagement/{workspaceId}/unlinkWorkspaceFromGoal": {
       "post": {
-        "operationId": "unlinkManageWorkspaceFromGoal",
+        "operationId": "unlinkWorkspaceFromGoal",
         "parameters": [
           {
             "in": "path",
@@ -47128,13 +50036,6 @@
             "required": true,
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
-              "type": "string"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "X-Domino-PmApiToken",
-            "schema": {
               "type": "string"
             }
           }
@@ -47235,7 +50136,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "type": "String"
           },
           {
             "description": "Id of the project",
@@ -47245,7 +50147,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           }
         ],
         "responses": {
@@ -47312,7 +50215,7 @@
     },
     "/projects/dontCall": {
       "get": {
-        "operationId": "getProjectStatuses",
+        "operationId": "notFound",
         "responses": {
           "200": {
             "content": {
@@ -47928,7 +50831,7 @@
     },
     "/projects/portfolio/moveProjectToStage": {
       "post": {
-        "operationId": "movePortfolioProjectToStage",
+        "operationId": "moveProjectToStage",
         "parameters": [],
         "requestBody": {
           "content": {
@@ -48374,6 +51277,126 @@
         ]
       }
     },
+    "/projects/{projectId}/addManyCollaborators": {
+      "post": {
+        "operationId": "addManyCollaborators",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.AddManyCollaborators"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "add many project collaborators",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/anonymousRunExecutionSettings": {
+      "get": {
+        "operationId": "getProjectAnonymousRunExecutionSettings",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "get project anonymous run execution setting for the given project id",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "patch": {
+        "operationId": "updateProjectAnonymousRunExecutionSettings",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.UpdateProjectAnonymousRunExecutionSettings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "update project anonymous run execution setting for the given project id",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
     "/projects/{projectId}/archiveCommentOnBlockedProject": {
       "delete": {
         "operationId": "archiveCommentOnBlockedProject",
@@ -48425,6 +51448,50 @@
           }
         },
         "summary": "Archive comment on blocked project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/collaboratorRole": {
+      "patch": {
+        "operationId": "updateCollaboratorProjectRole",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.CollaboratorDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "update project collaborator role",
         "tags": [
           "Projects"
         ]
@@ -48751,7 +51818,7 @@
     },
     "/projects/{projectId}/comments": {
       "get": {
-        "operationId": ";ostCommentsOnProject",
+        "operationId": "getCommentsOnProject",
         "parameters": [
           {
             "description": "Domino id of the project",
@@ -49853,7 +52920,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -49866,7 +52933,7 @@
               "format": "int32",
               "minimum": 1,
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -49930,6 +52997,77 @@
           }
         },
         "summary": "retrieves list of a repository's branches",
+        "tags": [
+          "Projects",
+          "Git"
+        ]
+      }
+    },
+    "/projects/{projectId}/gitRepositories/{repositoryId}/git/branches/{newBranchName}": {
+      "post": {
+        "operationId": "createBranch",
+        "parameters": [
+          {
+            "description": "Id of the project to get the repository from.",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of the repository to create the branch in.",
+            "in": "path",
+            "name": "repositoryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The name of the new branch to create",
+            "in": "path",
+            "name": "newBranchName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional parent branch. Uses default branch if empty.",
+            "in": "query",
+            "name": "fromBranchName",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.repositories.responses.CreateBranchApiResponse"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Creates a new branch on the repository",
         "tags": [
           "Projects",
           "Git"
@@ -50074,6 +53212,258 @@
           }
         },
         "summary": "retrieves list of a repository's commits",
+        "tags": [
+          "Projects",
+          "Git"
+        ]
+      }
+    },
+    "/projects/{projectId}/gitRepositories/{repositoryId}/git/fileMetadata": {
+      "get": {
+        "operationId": "getRepoFileMetadata",
+        "parameters": [
+          {
+            "description": "Id of the project to get the file from",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of the repository being queried. You can use \"_\" to refer to the project's mainRepository.",
+            "in": "path",
+            "name": "repositoryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The full path to the file to retrieve",
+            "in": "query",
+            "name": "fileName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A branch name to retrieve the file for. Defaults to the default set by the domino project, or if one doesn't exist, the repository's default. This parameter will be ignored if `commit` is provided.\n",
+            "in": "query",
+            "name": "branchName",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "A commit SHA to retrieve the file for. This parameter will take priority over `branchName`.\n",
+            "in": "query",
+            "name": "commit",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "gets metadata about the file from a repository",
+        "tags": [
+          "Projects",
+          "Git"
+        ]
+      }
+    },
+    "/projects/{projectId}/gitRepositories/{repositoryId}/git/files": {
+      "get": {
+        "deprecated": true,
+        "operationId": "getRepoFiles",
+        "parameters": [
+          {
+            "description": "Id of the project to get the repository from.",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of the repository being queried. You can use \"_\" to refer to the project's mainRepository.",
+            "in": "path",
+            "name": "repositoryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A branch name to browse the repository at. Defaults to the default set by the domino project, or if one doesn't exist, the repository's default. This parameter will be ignored if `commit` is provided.\n",
+            "in": "query",
+            "name": "branchName",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "A commit SHA to browse the repository at. This parameter will take priority over `branchName`.\n",
+            "in": "query",
+            "name": "commit",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "File search parameter to filter by.",
+            "in": "query",
+            "name": "searchPattern",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of results to return.",
+            "in": "query",
+            "name": "maxResults",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.repositories.responses.GitApiResponseWrapper[domino.projects.api.repositories.responses.GetRepoFilesApiResponse]"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "gets a list of a repository's files",
+        "tags": [
+          "Projects",
+          "Git"
+        ]
+      }
+    },
+    "/projects/{projectId}/gitRepositories/{repositoryId}/git/filesV2": {
+      "post": {
+        "operationId": "getRepoFilesV2",
+        "parameters": [
+          {
+            "description": "Id of the project to get the repository from.",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of the repository being queried. You can use \"_\" to refer to the project's mainRepository.",
+            "in": "path",
+            "name": "repositoryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "File search parameter to filter by.",
+            "in": "query",
+            "name": "searchPattern",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of results to return.",
+            "in": "query",
+            "name": "maxResults",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.repositories.ReferenceDTO"
+              }
+            }
+          },
+          "description": "Git reference object that contains a reference type and an optional reference value",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.repositories.responses.GitApiResponseWrapper[domino.projects.api.repositories.responses.GetRepoFilesApiResponse]"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "gets a list of a repository's files",
         "tags": [
           "Projects",
           "Git"
@@ -50230,6 +53620,80 @@
           }
         },
         "summary": "gets a repository's default readme filename",
+        "tags": [
+          "Projects",
+          "Git"
+        ]
+      }
+    },
+    "/projects/{projectId}/gitRepositories/{repositoryId}/git/render": {
+      "get": {
+        "operationId": "renderRepoFile",
+        "parameters": [
+          {
+            "description": "Id of the project to get the file from",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of the repository being queried. You can use \"_\" to refer to the project's mainRepository.",
+            "in": "path",
+            "name": "repositoryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The full path to the file to retrieve",
+            "in": "query",
+            "name": "fileName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A branch name to retrieve the file for. Defaults to the default set by the domino project, or if one doesn't exist, the repository's default. This parameter will be ignored if `commit` is provided.\n",
+            "in": "query",
+            "name": "branchName",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "A commit SHA to retrieve the file for. This parameter will take priority over `branchName`.\n",
+            "in": "query",
+            "name": "commit",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "returns html to render the file contents",
         "tags": [
           "Projects",
           "Git"
@@ -50656,6 +54120,124 @@
         ]
       }
     },
+    "/projects/{projectId}/kerberosConfig": {
+      "get": {
+        "operationId": "getProjectKerberosConfig",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectKerberosConfig"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "retrieves the specified project's kerberos config",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "post": {
+        "operationId": "updateProjectKerberosConfig",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "kerberosMode": {
+                    "required": true,
+                    "type": "string"
+                  },
+                  "keytabFileName": {
+                    "type": "string"
+                  },
+                  "principal": {
+                    "type": "string"
+                  },
+                  "upfile": {
+                    "description": "The file to upload",
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Project kerberos config",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectKerberosConfig"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "update the specified project's kerberos config",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
     "/projects/{projectId}/launcherJob/{launcherId}": {
       "post": {
         "operationId": "startLauncherJob",
@@ -50697,7 +54279,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/domino.common.DominoId"
                 }
               }
             },
@@ -50722,6 +54304,204 @@
         "summary": "starts an existing launcher job",
         "tags": [
           "Launchers"
+        ]
+      }
+    },
+    "/projects/{projectId}/name": {
+      "patch": {
+        "operationId": "updateProjectName",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.UpdateProjectName"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "update project name for this given projectId",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/notificationPreference": {
+      "patch": {
+        "operationId": "updateNotificationPreference",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.UpdateProjectNotificationPreference"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "update project notifications preference",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/projectSettingsCollaborators": {
+      "get": {
+        "operationId": "getProjectSettingsCollaborators",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "get project settings collaborators and preferences",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/projectSettingsExport": {
+      "get": {
+        "operationId": "getProjectSettingsExport",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "get project settings export",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "patch": {
+        "operationId": "updateProjectSettingsExport",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.ProjectSettingsExport"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "update project settings export",
+        "tags": [
+          "Projects"
         ]
       }
     },
@@ -50850,7 +54630,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/domino.common.DominoId"
                 }
               }
             },
@@ -50934,6 +54714,456 @@
           }
         },
         "summary": "set credential to use for a specific user-project-repo combination",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/requireCommitMessage": {
+      "get": {
+        "operationId": "getRequireCommitMessage",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "get if commit message is required for a project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/requireCommitMessage/{requireCommitMessage}": {
+      "patch": {
+        "operationId": "setRequireCommitMessage",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "should a commit message be required",
+            "in": "path",
+            "name": "requireCommitMessage",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "require a commit message for a project",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/resolveRequest/{reviewRequestNumber}": {
+      "patch": {
+        "operationId": "resolveReviewRequest",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of the review request",
+            "in": "path",
+            "name": "reviewRequestNumber",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.ResolveReviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Resolve a project review request",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/resultsBranchSetting": {
+      "get": {
+        "operationId": "getResultsBranchSetting",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectResultsBranchSettingChoices"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Gets the project results branch setting",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "patch": {
+        "operationId": "updateResultsBranchSetting",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.ProjectResultsBranchSettingChoices"
+              }
+            }
+          },
+          "description": "JSON object with isolatedOutputCommit Main or Isolated to update the results branch",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectResultsBranchSettingChoices"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Update project settings results branch",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/reviewRequest/{reviewRequestNumber}": {
+      "get": {
+        "operationId": "getReviewRequest",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of the review request",
+            "in": "path",
+            "name": "reviewRequestNumber",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get one project review request",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "patch": {
+        "operationId": "updateReviewRequest",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of the review request",
+            "in": "path",
+            "name": "reviewRequestNumber",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.UpdateReviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Update a project review request",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
+    "/projects/{projectId}/reviewRequests": {
+      "get": {
+        "operationId": "getReviewRequests",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Gets the project review requests as a list",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "post": {
+        "operationId": "createReviewRequest",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.CreateReviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Create a project review request",
         "tags": [
           "Projects"
         ]
@@ -51349,6 +55579,104 @@
         ]
       }
     },
+    "/projects/{projectId}/sparkConfig": {
+      "get": {
+        "operationId": "getProjectSparkConfig",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectSparkConfig"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "retrieves the specified project's spark config",
+        "tags": [
+          "Projects"
+        ]
+      },
+      "patch": {
+        "operationId": "updateProjectSparkConfig",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.ProjectSparkConfig"
+              }
+            }
+          },
+          "description": "Project apachespark config",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectSparkConfig"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "updates the specified project's spark config",
+        "tags": [
+          "Projects"
+        ]
+      }
+    },
     "/projects/{projectId}/tags": {
       "post": {
         "operationId": "addTags",
@@ -51748,7 +56076,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -51821,7 +56149,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -51894,7 +56222,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -51958,7 +56286,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "String"
                 }
               }
             },
@@ -52142,6 +56470,7 @@
           "200": {
             "content": {
               "application/json": {
+                "required": false,
                 "schema": {
                   "$ref": "#/components/schemas/domino.quota.api.QuotaDto"
                 }
@@ -52473,9 +56802,481 @@
         ]
       }
     },
+    "/serviceAccounts": {
+      "get": {
+        "operationId": "listServiceAccounts",
+        "parameters": [
+          {
+            "description": "If true, the list will include deactivated service accounts. Default value is false.",
+            "in": "query",
+            "name": "includeDeactivated",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.admin.interface.ServiceAccount"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "retrieves a list of service account",
+        "tags": [
+          "ServiceAccounts"
+        ]
+      },
+      "post": {
+        "operationId": "createServiceAccount",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.admin.interface.CreateServiceAccountRequest"
+              }
+            }
+          },
+          "description": "Create service account request",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Create a new service account",
+        "tags": [
+          "ServiceAccounts"
+        ]
+      }
+    },
+    "/serviceAccounts/{serviceAccountIdpId}/activate": {
+      "post": {
+        "operationId": "activateServiceAccount",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "serviceAccountIdpId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "serviceAccountIpdId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Activate a service account",
+        "tags": [
+          "ServiceAccounts"
+        ]
+      }
+    },
+    "/serviceAccounts/{serviceAccountIdpId}/deactivate": {
+      "post": {
+        "operationId": "deactivateServiceAccount",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "serviceAccountIdpId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "serviceAccountIpdId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Deactivate a service account",
+        "tags": [
+          "ServiceAccounts"
+        ]
+      }
+    },
+    "/serviceAccounts/{serviceAccountIdpId}/resetpassword": {
+      "post": {
+        "operationId": "resetServiceAccountPassword",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "serviceAccountIdpId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "serviceAccountIpdId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Regenerate and synchronize service account's password, update both local storage and keycloak",
+        "tags": [
+          "ServiceAccounts"
+        ]
+      }
+    },
+    "/serviceAccounts/{serviceAccountIdpId}/tokens": {
+      "get": {
+        "operationId": "listServiceAccountTokens",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "serviceAccountIdpId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.admin.interface.ServiceAccountTokenMetadata"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "retrieves a list of service account",
+        "tags": [
+          "ServiceAccounts"
+        ]
+      },
+      "post": {
+        "operationId": "createServiceAccountToken",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "serviceAccountIdpId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.admin.interface.CreateServiceAccountTokenRequest"
+              }
+            }
+          },
+          "description": "Invalidate service account token request",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.admin.interface.ServiceAccountTokenMetadataAndToken"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Create a service account token",
+        "tags": [
+          "ServiceAccounts"
+        ]
+      }
+    },
+    "/serviceAccounts/{serviceAccountIdpId}/tokens/{serviceAccountTokenName}": {
+      "delete": {
+        "operationId": "deleteServiceAccountToken",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "serviceAccountIdpId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "serviceAccountTokenName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Delete a service account token",
+        "tags": [
+          "ServiceAccounts"
+        ]
+      },
+      "get": {
+        "operationId": "getServiceAccountToken",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "serviceAccountIdpId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "serviceAccountTokenName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "$ref": "#/components/schemas/domino.admin.interface.ServiceAccountTokenMetadataAndToken"
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get service account token, both metadata and the token itself",
+        "tags": [
+          "ServiceAccounts"
+        ]
+      }
+    },
+    "/serviceAccounts/{serviceAccountIdpId}/tokens/{serviceAccountTokenName}/invalidate": {
+      "post": {
+        "operationId": "invalidateServiceAccountToken",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "serviceAccountIdpId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "serviceAccountTokenName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Invalidate a service account token",
+        "tags": [
+          "ServiceAccounts"
+        ]
+      }
+    },
     "/tags": {
       "get": {
-        "operationId": "listTags",
+        "operationId": "list",
         "parameters": [
           {
             "description": "Optional filter for a tag by name",
@@ -52821,14 +57622,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "type": "boolean"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -52868,14 +57665,10 @@
         ],
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.common.user.LiteUserResponseDTO"
-                }
-              }
-            },
-            "description": "success"
+            "description": "success",
+            "schema": {
+              "$ref": "#/components/schemas/domino.common.user.LiteUserResponseDTO"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -52940,6 +57733,7 @@
             }
           },
           {
+            "default": "created",
             "description": "Specify sort criteria (optional, incompatible with defaultSort=true)",
             "in": "query",
             "name": "sort",
@@ -52958,6 +57752,7 @@
             }
           },
           {
+            "default": "desc",
             "description": "Specify sort direction (optional, incompatible with defaultSort=true)",
             "in": "query",
             "name": "dir",
@@ -52972,6 +57767,7 @@
             }
           },
           {
+            "default": false,
             "description": "If true, use the frontend's default sorting and return 400 if either 'sort' or 'dir' are set.",
             "in": "query",
             "name": "defaultSort",
@@ -53415,17 +58211,13 @@
         },
         "responses": {
           "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.modelmanager.web.BuildModelImageApiResponse"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Request accepted, building of model API image continues offline"
+            "description": "Request accepted, building of model API image continues offline",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.web.BuildModelImageApiResponse"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -53495,7 +58287,7 @@
     },
     "/v4/models/{exportId}/getExportLogs": {
       "get": {
-        "operationId": "getModelExportVersionLogs",
+        "operationId": "getExportVersionLogs",
         "parameters": [
           {
             "in": "path",
@@ -53576,17 +58368,13 @@
         },
         "responses": {
           "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of model API image continues offline"
+            "description": "Request accepted, exporting of model API image continues offline",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -53643,17 +58431,13 @@
         },
         "responses": {
           "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of model API image continues offline"
+            "description": "Request accepted, exporting of model API image continues offline",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -53676,7 +58460,7 @@
     },
     "/v4/models/{modelId}/{modelVersionId}/exportImageForSnowflake": {
       "post": {
-        "operationId": "exportModelImageForSnowflake",
+        "operationId": "exportImageForSnowflake",
         "parameters": [
           {
             "in": "path",
@@ -53710,17 +58494,13 @@
         },
         "responses": {
           "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of model API image continues offline"
+            "description": "Request accepted, exporting of model API image continues offline",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -53777,17 +58557,13 @@
         },
         "responses": {
           "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Request accepted, exporting of model API image continues offline"
+            "description": "Request accepted, exporting of model API image continues offline",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/domino.modelmanager.web.ModelExportVersionStatusApiResponse"
+              },
+              "type": "array"
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
@@ -53810,7 +58586,7 @@
     },
     "/v4/models/{modelId}/{modelVersionId}/getBuildLogs": {
       "get": {
-        "operationId": "getModelBuildLogs",
+        "operationId": "getBuildLogs",
         "parameters": [
           {
             "in": "path",
@@ -54278,7 +59054,7 @@
     },
     "/workspace/events": {
       "get": {
-        "operationId": "listWorkspaceEvents",
+        "operationId": "notFound",
         "responses": {
           "200": {
             "content": {
@@ -54313,7 +59089,7 @@
     "/workspace/getGlobalSettings": {
       "get": {
         "operationId": "getGlobalSettings",
-        "parameters": [],
+        "parameters": null,
         "responses": {
           "200": {
             "content": {
@@ -55133,7 +59909,7 @@
     },
     "/workspace/project/{projectId}/workspace/{workspaceId}/getWritableProjectMounts": {
       "get": {
-        "operationId": "listWritableProjectMounts",
+        "operationId": "getWritableProjectMounts",
         "parameters": [
           {
             "description": "project id",
@@ -55389,7 +60165,7 @@
     },
     "/workspace/project/{projectId}/workspace/{workspaceId}/updateTitle": {
       "post": {
-        "operationId": "updateProjectWorkspaceTitle",
+        "operationId": "updateWorkspaceTitle",
         "parameters": [
           {
             "description": "Id of the project",
@@ -55654,6 +60430,106 @@
         ]
       }
     },
+    "/workspace/workspaceSessionId/{workspaceSessionId}/provenanceCheckpoints": {
+      "get": {
+        "operationId": "getProvenanceCheckpointsForWorkspaceSession",
+        "parameters": [
+          {
+            "description": "ID of the execution corresponding to a workspace session",
+            "in": "path",
+            "name": "workspaceSessionId",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The number of items to skip.  Can not be negative.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The size of the page to return.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "A column name to sort over - createdAt, dfsBranch, executionStart, mainGitBranch - default is 'createdAt'.",
+            "in": "query",
+            "name": "sortBy",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/domino.provenance.api.SortableFields.Value",
+              "enum": [
+                "createdAt",
+                "dfsBranch",
+                "executionStart",
+                "mainGitBranch"
+              ],
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "order of sort.  default is 'desc'.",
+            "in": "query",
+            "name": "sortOrder",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.workspace.api.WorkspaceSessionProvenanceDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "summary": "Get the provenance checkpoints for a workspace session",
+        "tags": [
+          "Workspace"
+        ]
+      }
+    },
     "/workspace/{executionId}/getSessionByExecutionId": {
       "get": {
         "operationId": "getWorkspaceExecutionInfo",
@@ -55821,7 +60697,7 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
-        "summary": "Get the project snapshots for a workspace session",
+        "summary": "Deprecated, please use getProvenanceCheckpointsForWorkspaceSession instead",
         "tags": [
           "Workspace"
         ]
@@ -55829,7 +60705,7 @@
     },
     "/workspace/{executionId}/{clusterType}/hostAndPort": {
       "get": {
-        "operationId": "getWorkspaceComputeClusterHostAndPort",
+        "operationId": "getComputeClusterHostAndPort",
         "parameters": [
           {
             "description": "ID of the execution",
@@ -55925,7 +60801,7 @@
     },
     "/workspace/{projectId}/{clusterType}/defaultComputeClusterSettings": {
       "get": {
-        "operationId": "getWorkspaceDefaultComputeClusterSettings",
+        "operationId": "getDefaultComputeClusterSettings",
         "parameters": [
           {
             "description": "ID of the project",
@@ -55935,7 +60811,8 @@
             "schema": {
               "pattern": "^[0-9a-f]{24}$",
               "type": "string"
-            }
+            },
+            "type": "domino.common.DominoId"
           },
           {
             "description": "Type of the cluster to get settings for",
@@ -56010,7 +60887,7 @@
               "default": 10000,
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -56021,7 +60898,7 @@
             "schema": {
               "default": 0,
               "format": "int32",
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -56101,7 +60978,7 @@
               "default": 10000,
               "format": "int32",
               "nullable": true,
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -56112,7 +60989,7 @@
             "schema": {
               "default": 0,
               "format": "int32",
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -56845,7 +61722,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterDetails": {
       "get": {
-        "operationId": "getWorkspaceComputeClusterDetails",
+        "operationId": "getComputeClusterDetails",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -56900,7 +61777,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterFileSync": {
       "post": {
-        "operationId": "syncWorkspaceFilesToComputeCluster",
+        "operationId": "syncFilesToComputeCluster",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -56955,7 +61832,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterFileSyncStatus": {
       "get": {
-        "operationId": "getWorkspaceComputeClusterFileSyncStatus",
+        "operationId": "getComputeClusterFileSyncStatus",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -57010,7 +61887,7 @@
     },
     "/workspace/{workspaceSessionId}/computeClusterStatus": {
       "get": {
-        "operationId": "getWorkspaceComputeClusterStatus",
+        "operationId": "getComputeClusterStatus",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -57065,7 +61942,7 @@
     },
     "/workspace/{workspaceSessionId}/executionCheckpointStatuses": {
       "get": {
-        "operationId": "getExecutionCheckpointStatuses",
+        "operationId": "getExecutionCheckpointReport",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -57181,7 +62058,7 @@
     },
     "/workspace/{workspaceSessionId}/usage": {
       "get": {
-        "operationId": "getWorkspaceSessionResourceUsage",
+        "operationId": "getResourceUsage",
         "parameters": [
           {
             "description": "projectId associated with the workspace",
@@ -57406,7 +62283,7 @@
     },
     "/workspaces/events": {
       "get": {
-        "operationId": "getWorkspaceEvents",
+        "operationId": "notFound",
         "responses": {
           "200": {
             "content": {
@@ -57540,7 +62417,7 @@
     },
     "/workspaces/project/{projectId}/environment/{environmentId}/availableTools": {
       "get": {
-        "operationId": "getAvailableToolsForEnvironmentInWorkspace",
+        "operationId": "getAvailableToolsForEnvironment",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -58010,7 +62887,7 @@
     },
     "/workspaces/{workspaceId}/allComments": {
       "get": {
-        "operationId": "getAllWorkspaceComments",
+        "operationId": "getAllComments",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58170,7 +63047,7 @@
     },
     "/workspaces/{workspaceId}/comment/{threadId}": {
       "delete": {
-        "operationId": "archiveCommentFromThread",
+        "operationId": "archiveComment",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58235,7 +63112,7 @@
     },
     "/workspaces/{workspaceId}/comments": {
       "get": {
-        "operationId": "getWorkspaceComments",
+        "operationId": "getComments",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58280,7 +63157,7 @@
     },
     "/workspaces/{workspaceId}/executionCheckpointStatuses": {
       "get": {
-        "operationId": "getWorkspaceExecutionCheckpointStatuses",
+        "operationId": "getExecutionCheckpointStatuses",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58458,7 +63335,7 @@
     },
     "/workspaces/{workspaceId}/logs": {
       "get": {
-        "operationId": "getWorkspaceLogs",
+        "operationId": "getLogs",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58604,7 +63481,7 @@
     },
     "/workspaces/{workspaceId}/realTimeLogs": {
       "get": {
-        "operationId": "getWorkspaceRealTimeLogs",
+        "operationId": "getRealTimeLogs",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58698,7 +63575,7 @@
     },
     "/workspaces/{workspaceId}/resourceStatuses": {
       "get": {
-        "operationId": "getWorkspaceRepositoryResourceStatus",
+        "operationId": "getWorkspaceRepositoryStatus",
         "parameters": [
           {
             "description": "ID of the Project",
@@ -58753,7 +63630,7 @@
     },
     "/workspaces/{workspaceId}/resultFile/comments": {
       "get": {
-        "operationId": "getWorkspaceResultFileComments",
+        "operationId": "getResultFileComments",
         "parameters": [
           {
             "description": "ID of the workspace",
@@ -58816,7 +63693,7 @@
     },
     "/workspaces/{workspaceId}/results": {
       "get": {
-        "operationId": "getWorkspaceResults",
+        "operationId": "getResults",
         "parameters": [
           {
             "description": "ProjectId associated with the workspace",
@@ -58871,7 +63748,7 @@
     },
     "/workspaces/{workspaceId}/runtimeExecutionDetails": {
       "get": {
-        "operationId": "getWorkspaceRuntimeExecutionDetails",
+        "operationId": "getRuntimeExecutionDetails",
         "parameters": [
           {
             "description": "ProjectId for the workspace",
@@ -59241,7 +64118,7 @@
     },
     "/workspaces/{workspaceId}/usage": {
       "get": {
-        "operationId": "getWorkspaceResourceUsage",
+        "operationId": "getResourceUsage",
         "parameters": [
           {
             "description": "ProjectId associated with the workspace",

--- a/src/conf/domino-public-api.json
+++ b/src/conf/domino-public-api.json
@@ -90,6 +90,24 @@
       }
     },
     "schemas": {
+      "AIGatewayEnvelopeV1": {
+        "properties": {
+          "endpoints": {
+            "items": {
+              "$ref": "#/components/schemas/EndpointEnvelopeV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "endpoints",
+          "metadata"
+        ],
+        "type": "object"
+      },
       "AsyncPredictionEnvelopeV1": {
         "properties": {
           "asyncPredictionId": {
@@ -162,6 +180,144 @@
           "projectID",
           "serviceKeyName",
           "serviceKeySecret"
+        ],
+        "type": "object"
+      },
+      "BillingTagEnvelopeV1": {
+        "properties": {
+          "billingTag": {
+            "$ref": "#/components/schemas/BillingTagWithStatusV1"
+          }
+        },
+        "required": [
+          "billingTag"
+        ],
+        "type": "object"
+      },
+      "BillingTagV1": {
+        "properties": {
+          "tag": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag"
+        ],
+        "type": "object"
+      },
+      "BillingTagWithStatusV1": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "tag": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag",
+          "active"
+        ],
+        "type": "object"
+      },
+      "BillingTagsEnvelopeV1": {
+        "properties": {
+          "billingTags": {
+            "items": {
+              "$ref": "#/components/schemas/BillingTagV1"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "billingTags"
+        ],
+        "type": "object"
+      },
+      "BillingTagsModeEnvelopeV1": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/BillingTagsSettingModeV1"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
+      "BillingTagsModeV1": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/BillingTagsSettingModeV1"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
+      "BillingTagsNotificationsEnvelopeV1": {
+        "properties": {
+          "notifications": {
+            "$ref": "#/components/schemas/BillingTagsSettingNotificationsV1"
+          }
+        },
+        "required": [
+          "notifications"
+        ],
+        "type": "object"
+      },
+      "BillingTagsNotificationsV1": {
+        "properties": {
+          "notifications": {
+            "$ref": "#/components/schemas/BillingTagsSettingNotificationsV1"
+          }
+        },
+        "required": [
+          "notifications"
+        ],
+        "type": "object"
+      },
+      "BillingTagsSettingModeV1": {
+        "description": "Billing tags functionality mode",
+        "enum": [
+          "required",
+          "optional",
+          "disabled"
+        ],
+        "type": "string"
+      },
+      "BillingTagsSettingNotificationsV1": {
+        "description": "Billing tags notifications setting",
+        "type": "boolean"
+      },
+      "BillingTagsSettingsEnvelopeV1": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/BillingTagsSettingModeV1"
+          },
+          "notifications": {
+            "$ref": "#/components/schemas/BillingTagsSettingNotificationsV1"
+          }
+        },
+        "required": [
+          "mode",
+          "notifications"
+        ],
+        "type": "object"
+      },
+      "BillingTagsSettingsV1": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/BillingTagsSettingModeV1"
+          },
+          "notifications": {
+            "$ref": "#/components/schemas/BillingTagsSettingNotificationsV1"
+          }
+        },
+        "required": [
+          "mode",
+          "notifications"
         ],
         "type": "object"
       },
@@ -240,37 +396,6 @@
         ],
         "type": "object"
       },
-      "CopyProjectSpecBeta": {
-        "properties": {
-          "copyDatasets": {
-            "description": "Whether to copy the Project's datasets or not",
-            "type": "boolean"
-          },
-          "gitCodeRepoSpec": {
-            "$ref": "#/components/schemas/GitCodeRepoSpecBeta"
-          },
-          "importedGitReposCredentialId": {
-            "description": "The Domino ID of the PAT credential, which will be used to access the Imported Git Repos on the new project.",
-            "type": "string"
-          },
-          "name": {
-            "description": "The name of the new Domino Project.",
-            "type": "string"
-          },
-          "ownerId": {
-            "description": "The Domino ID of owner of the copied project.",
-            "type": "string"
-          },
-          "visibility": {
-            "$ref": "#/components/schemas/ProjectVisibilityV1",
-            "description": "The visibility of the new Project."
-          }
-        },
-        "required": [
-          "copyDatasets"
-        ],
-        "type": "object"
-      },
       "CopyProjectSpecV1": {
         "properties": {
           "copyDatasets": {
@@ -319,52 +444,40 @@
       "CostAllocationV1": {
         "properties": {
           "cpuCoreHours": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "cpuCoreRequestAverage": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "cpuCoreUsageAverage": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "cpuCores": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "cpuCost": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "cpuCostAdjustment": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "cpuEfficincy": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "discount": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "gpuCount": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "gpuHours": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "gpucost": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "gpucostAdjustment": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "labels": {
             "properties": {
@@ -402,12 +515,10 @@
             "type": "object"
           },
           "loadBalancerCost": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "loadBalancerCostAdjustment": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "name": {
             "type": "string"
@@ -418,31 +529,25 @@
           "pv": {
             "properties": {
               "pvByteHours": {
-                "format": "double",
-                "type": "integer"
+                "type": "double"
               },
               "pvBytes": {
-                "format": "double",
-                "type": "integer"
+                "type": "double"
               },
               "pvCost": {
-                "format": "double",
-                "type": "integer"
+                "type": "double"
               },
               "pvCostAdjustment": {
-                "format": "double",
-                "type": "integer"
+                "type": "double"
               },
               "pvs": {
                 "additionalProperties": {
                   "properties": {
                     "byteHours": {
-                      "format": "double",
-                      "type": "integer"
+                      "type": "double"
                     },
                     "cost": {
-                      "format": "double",
-                      "type": "integer"
+                      "type": "double"
                     }
                   },
                   "type": "object"
@@ -453,16 +558,13 @@
             "type": "object"
           },
           "ramCost": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "ramCostAdjustment": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "totalCost": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "window": {
             "properties": {
@@ -470,8 +572,7 @@
                 "type": "string"
               },
               "minutes": {
-                "format": "double",
-                "type": "integer"
+                "type": "double"
               },
               "start": {
                 "type": "string"
@@ -499,12 +600,10 @@
       "CostAssetsV1": {
         "properties": {
           "cpuCost": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "gpuCost": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "labels": {
             "properties": {
@@ -547,18 +646,17 @@
             "type": "object"
           },
           "ramCost": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "totalCost": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "type": {
             "type": "string"
           },
           "window": {
-            "$ref": "#/components/schemas/CostAssetsV1Window"
+            "$ref": "#/components/schemas/CostAssetsV1Window",
+            "type": "object"
           }
         },
         "type": "object"
@@ -569,8 +667,7 @@
             "type": "string"
           },
           "minutes": {
-            "format": "double",
-            "type": "integer"
+            "type": "double"
           },
           "start": {
             "type": "string"
@@ -581,16 +678,15 @@
       "DataSourceAuditDataV1": {
         "properties": {
           "dataSourceId": {
-            "description": "ID of the datasource",
+            "description": "ID of the Data Source",
             "type": "string"
           },
           "dataSourceName": {
-            "description": "name of the datasource",
+            "description": "name of the Data Source",
             "type": "string"
           },
           "dataSourceType": {
-            "description": "type of the datasource",
-            "type": "string"
+            "$ref": "#/components/schemas/DataSourceTypeV1"
           },
           "eventKind": {
             "$ref": "#/components/schemas/DataSourceAuditEventKindV1"
@@ -621,7 +717,7 @@
         "type": "object"
       },
       "DataSourceAuditEventKindV1": {
-        "description": "Kinds of datasource audit events",
+        "description": "Kinds of Data Source audit events",
         "enum": [
           "AccessDataSource",
           "CreateDataSource",
@@ -640,6 +736,160 @@
         "description": "A map of string -> string",
         "example": {
           "foo": "bar"
+        },
+        "type": "object"
+      },
+      "DataSourceAuthTypeV1": {
+        "description": "The type of Data Source authentication",
+        "example": "AzureBasic",
+        "type": "string"
+      },
+      "DataSourceConfigV1": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "A map of configuration name -> value",
+        "example": {
+          "host": "example-host.com"
+        },
+        "type": "object"
+      },
+      "DataSourceCredentialTypeV1": {
+        "description": "Whether the credentials is individual to a user or shared",
+        "enum": [
+          "Individual",
+          "Shared"
+        ],
+        "type": "string"
+      },
+      "DataSourceCredentialsV1": {
+        "properties": {
+          "secretCredentials": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Map of secret credentials fields -> value",
+            "type": "object"
+          },
+          "visibleCredentials": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Map of non-secret credentials fields -> value",
+            "type": "object"
+          }
+        },
+        "required": [
+          "visibleCredentials",
+          "secretCredentials"
+        ],
+        "type": "object"
+      },
+      "DataSourceEnvelopeV1": {
+        "properties": {
+          "authType": {
+            "$ref": "#/components/schemas/DataSourceAuthTypeV1"
+          },
+          "config": {
+            "$ref": "#/components/schemas/DataSourceConfigV1"
+          },
+          "credentialType": {
+            "$ref": "#/components/schemas/DataSourceCredentialTypeV1"
+          },
+          "dataSourceType": {
+            "$ref": "#/components/schemas/DataSourceTypeV1"
+          },
+          "description": {
+            "description": "Description of the Data Source",
+            "example": "My Data Source",
+            "type": "string"
+          },
+          "displayName": {
+            "description": "Data Source display name",
+            "example": "Azure Data Lake Store",
+            "type": "string"
+          },
+          "id": {
+            "description": "ID of the Data Source",
+            "example": "62604702b7e5d347dbe7a909",
+            "type": "string"
+          },
+          "lastUpdated": {
+            "description": "ISO 8601 formatted time of when the Data Source was last updated",
+            "example": "2022-04-23T18:25:43.511Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "description": "User given name of the Data Source",
+            "example": "data-source-name",
+            "type": "string"
+          },
+          "ownerId": {
+            "description": "ID of the Data Source owner",
+            "example": "62604702b7e5d347dbe7a909",
+            "type": "string"
+          },
+          "ownerUsername": {
+            "description": "Username of the owner of the Data Source",
+            "example": "owner-username",
+            "type": "string"
+          },
+          "permissions": {
+            "$ref": "#/components/schemas/DataSourcePermissionsV1"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "ownerId",
+          "ownerUsername",
+          "dataSourceType",
+          "authType",
+          "credentialType",
+          "config",
+          "permissions",
+          "lastUpdated",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "DataSourcePermissionsV1": {
+        "properties": {
+          "isEveryone": {
+            "description": "If the Data Source is accessible by everyone",
+            "type": "boolean"
+          },
+          "userAndOrganizationIds": {
+            "description": "User and Organization IDs that can access this Data Source",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "isEveryone",
+          "userAndOrganizationIds"
+        ],
+        "type": "object"
+      },
+      "DataSourceTypeV1": {
+        "description": "The configuration type of the Data Source",
+        "example": "ADLSConfig",
+        "type": "string"
+      },
+      "DataSourceUpdateV1": {
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/DataSourceConfigV1"
+          },
+          "credentials": {
+            "$ref": "#/components/schemas/DataSourceCredentialsV1"
+          },
+          "permissions": {
+            "$ref": "#/components/schemas/DataSourcePermissionsV1"
+          }
         },
         "type": "object"
       },
@@ -996,29 +1246,6 @@
         ],
         "type": "object"
       },
-      "DeepCopyGitRepoSpecBeta": {
-        "description": "Data which specifies what the copied repository will look like.",
-        "properties": {
-          "isPrivate": {
-            "description": "Whether or not the new code repo should be private.",
-            "type": "boolean"
-          },
-          "newRepoName": {
-            "description": "The name of the new repository.",
-            "type": "string"
-          },
-          "newRepoOwnerName": {
-            "description": "The name of the user who will own the new repository in the git service provider.",
-            "type": "string"
-          }
-        },
-        "required": [
-          "newRepoName",
-          "newRepoOwnerName",
-          "isPrivate"
-        ],
-        "type": "object"
-      },
       "DeepCopyGitRepoSpecV1": {
         "description": "Data which specifies what the copied repository will look like.",
         "properties": {
@@ -1072,6 +1299,67 @@
         "required": [
           "name",
           "value"
+        ],
+        "type": "object"
+      },
+      "EndpointEnvelopeV1": {
+        "properties": {
+          "endpointId": {
+            "description": "ID of the endpoint",
+            "example": "62604702b7e5d347dbe7a909",
+            "type": "string"
+          },
+          "endpointName": {
+            "description": "Valid name of the endpoint",
+            "example": "completions",
+            "type": "string"
+          },
+          "endpointType": {
+            "description": "Type of the endpoint",
+            "example": "llm/v1/completions",
+            "type": "string"
+          },
+          "modelConfig": {
+            "$ref": "#/components/schemas/ModelConfigV1"
+          },
+          "modelName": {
+            "description": "Name of the model",
+            "example": "gpt-4",
+            "type": "string"
+          },
+          "modelProvider": {
+            "description": "Provider of the model",
+            "example": "openai",
+            "type": "string"
+          }
+        },
+        "required": [
+          "endpointId",
+          "endpointName",
+          "endpointType",
+          "modelProvider",
+          "modelName",
+          "modelConfig"
+        ],
+        "type": "object"
+      },
+      "EndpointPermissionsDtoV1": {
+        "properties": {
+          "isEveryoneAllowed": {
+            "description": "If the endpoint is accessible by everyone",
+            "type": "boolean"
+          },
+          "userIds": {
+            "description": "User IDs that can access this endpoint",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "isEveryoneAllowed",
+          "userIds"
         ],
         "type": "object"
       },
@@ -1382,25 +1670,6 @@
         ],
         "type": "object"
       },
-      "GitCodeRepoSpecBeta": {
-        "description": "Details needed in order to copy the code repository of a Git-backed project.",
-        "properties": {
-          "credentialId": {
-            "description": "The Domino ID of the PAT credential, which will be used to copy and/or read from the code repository on the new project.",
-            "type": "string"
-          },
-          "deepCopy": {
-            "$ref": "#/components/schemas/DeepCopyGitRepoSpecBeta"
-          },
-          "referenceCopy": {
-            "$ref": "#/components/schemas/ReferenceCopyGitRepoSpecV1"
-          }
-        },
-        "required": [
-          "credentialId"
-        ],
-        "type": "object"
-      },
       "GitCodeRepoSpecV1": {
         "description": "Details needed in order to copy the code repository of a Git-backed project.",
         "properties": {
@@ -1519,16 +1788,346 @@
             "description": "Id of Goal to link to Job.",
             "example": "62313cfd7a0af0281c01a6a6",
             "type": "string"
+          }
+        },
+        "required": [
+          "goalId"
+        ],
+        "type": "object"
+      },
+      "HardwareTierCapacityV1": {
+        "description": "Current capacity information for a hardware tier. Note: Not necessary on requests to update a hardware tier.",
+        "properties": {
+          "availableCapacityWithoutLaunching": {
+            "type": "integer"
           },
-          "projectId": {
-            "description": "Id of project resources belong to.",
-            "example": "62313d377a0af0281c01a6a8",
+          "capacityLevel": {
+            "enum": [
+              "CanExecuteWithCurrentInstances",
+              "RequiresLaunchingInstance",
+              "Full",
+              "Unknown"
+            ],
+            "type": "string"
+          },
+          "executingRuns": {
+            "type": "integer"
+          },
+          "maxAvailableCapacity": {
+            "type": "integer"
+          },
+          "maxConcurrentRuns": {
+            "type": "integer"
+          },
+          "maxNumberOfExecutors": {
+            "type": "integer"
+          },
+          "numberOfExecutors": {
+            "type": "integer"
+          },
+          "queuedRuns": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "numberOfExecutors",
+          "maxNumberOfExecutors",
+          "executingRuns",
+          "queuedRuns",
+          "maxConcurrentRuns",
+          "availableCapacityWithoutLaunching",
+          "maxAvailableCapacity",
+          "capacityLevel"
+        ],
+        "type": "object"
+      },
+      "HardwareTierComputeClusterRestrictionsV1": {
+        "description": "Details about specific compute clusters a hardware tier is restricted to",
+        "properties": {
+          "restrictToDask": {
+            "type": "boolean"
+          },
+          "restrictToMpi": {
+            "type": "boolean"
+          },
+          "restrictToRay": {
+            "type": "boolean"
+          },
+          "restrictToSpark": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "restrictToSpark",
+          "restrictToRay",
+          "restrictToDask",
+          "restrictToMpi"
+        ],
+        "type": "object"
+      },
+      "HardwareTierEnvelopeV1": {
+        "properties": {
+          "hardwareTier": {
+            "$ref": "#/components/schemas/HardwareTierV1"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/MetadataV1"
+          }
+        },
+        "required": [
+          "hardwareTier",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "HardwareTierFlagsV1": {
+        "description": "Boolean flags for a hardware tier",
+        "properties": {
+          "isArchived": {
+            "type": "boolean"
+          },
+          "isDataAnalystTier": {
+            "type": "boolean"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "isDefaultForModelApi": {
+            "type": "boolean"
+          },
+          "isGlobal": {
+            "type": "boolean"
+          },
+          "isModelApiTier": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "isDefault",
+          "isVisible",
+          "isGlobal",
+          "isArchived",
+          "isDataAnalystTier"
+        ],
+        "type": "object"
+      },
+      "HardwareTierGpuConfigurationV1": {
+        "description": "Gpu configuration for a hardware tier",
+        "properties": {
+          "gpuKey": {
+            "type": "string"
+          },
+          "numberOfGpus": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "numberOfGpus",
+          "gpuKey"
+        ],
+        "type": "object"
+      },
+      "HardwareTierOverProvisioningV1": {
+        "description": "Over provisioning settings for a hardware tier",
+        "properties": {
+          "daysOfWeek": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "fromTime": {
+            "type": "string"
+          },
+          "instances": {
+            "type": "integer"
+          },
+          "schedulingEnabled": {
+            "type": "boolean"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "toTime": {
             "type": "string"
           }
         },
         "required": [
-          "goalId",
-          "projectId"
+          "instances",
+          "schedulingEnabled",
+          "daysOfWeek",
+          "timezone",
+          "fromTime",
+          "toTime"
+        ],
+        "type": "object"
+      },
+      "HardwareTierPodCustomizationV1": {
+        "description": "Custom fields for hardwareTier",
+        "properties": {
+          "additionalAnnotations": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "additionalLabels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "additionalLimits": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "additionalRequests": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "capabilities": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "hugepages": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "HardwareTierResourcesV1": {
+        "description": "Compute resources for a hardware tier",
+        "properties": {
+          "allowSharedMemoryToExceedDefault": {
+            "type": "boolean"
+          },
+          "cores": {
+            "example": 1,
+            "format": "double",
+            "type": "number"
+          },
+          "coresLimit": {
+            "format": "double",
+            "type": "number"
+          },
+          "memory": {
+            "$ref": "#/components/schemas/InformationV1"
+          },
+          "memoryLimit": {
+            "$ref": "#/components/schemas/InformationV1"
+          },
+          "memorySwapLimit": {
+            "$ref": "#/components/schemas/InformationV1"
+          },
+          "sharedMemoryLimit": {
+            "$ref": "#/components/schemas/InformationV1"
+          }
+        },
+        "required": [
+          "cores",
+          "memory",
+          "allowSharedMemoryToExceedDefault"
+        ],
+        "type": "object"
+      },
+      "HardwareTierV1": {
+        "properties": {
+          "availabilityZones": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "capacity": {
+            "$ref": "#/components/schemas/HardwareTierCapacityV1"
+          },
+          "centsPerMinute": {
+            "description": "Cost per minute of using this hardware tier as defined by an Admin.",
+            "format": "double",
+            "type": "number"
+          },
+          "computeClusterRestrictions": {
+            "$ref": "#/components/schemas/HardwareTierComputeClusterRestrictionsV1"
+          },
+          "creationTime": {
+            "description": "When the hardware tier was created",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "dataPlaneId": {
+            "type": "string"
+          },
+          "flags": {
+            "$ref": "#/components/schemas/HardwareTierFlagsV1"
+          },
+          "gpuConfiguration": {
+            "$ref": "#/components/schemas/HardwareTierGpuConfigurationV1"
+          },
+          "id": {
+            "example": "small-k8s",
+            "type": "string"
+          },
+          "maxSimultaneousExecutions": {
+            "type": "integer"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "example": "My-HardwareTier",
+            "type": "string"
+          },
+          "nodePool": {
+            "type": "string"
+          },
+          "overProvisioning": {
+            "$ref": "#/components/schemas/HardwareTierOverProvisioningV1"
+          },
+          "podCustomization": {
+            "$ref": "#/components/schemas/HardwareTierPodCustomizationV1"
+          },
+          "resources": {
+            "$ref": "#/components/schemas/HardwareTierResourcesV1"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "updateTime": {
+            "description": "When the hardwareTier was last updated",
+            "example": "2022-03-12T02:13:44.467Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "resources",
+          "flags",
+          "centsPerMinute",
+          "creationTime",
+          "updateTime",
+          "podCustomization",
+          "metadata"
         ],
         "type": "object"
       },
@@ -1550,6 +2149,28 @@
         "required": [
           "status",
           "version"
+        ],
+        "type": "object"
+      },
+      "InformationV1": {
+        "properties": {
+          "units": {
+            "enum": [
+              "MB",
+              "MiB",
+              "GB",
+              "GiB"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "value",
+          "units"
         ],
         "type": "object"
       },
@@ -2122,6 +2743,16 @@
         ],
         "type": "object"
       },
+      "ModelConfigV1": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "Configuration for the model",
+        "example": {
+          "openai": "58utu49034093nc9cc9n"
+        },
+        "type": "object"
+      },
       "MountedGitRepoV1": {
         "properties": {
           "endingBranch": {
@@ -2206,6 +2837,62 @@
         ],
         "type": "object"
       },
+      "NewBillingTagsV1": {
+        "properties": {
+          "billingTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "billingTags"
+        ],
+        "type": "object"
+      },
+      "NewDataSourceV1": {
+        "properties": {
+          "authType": {
+            "$ref": "#/components/schemas/DataSourceAuthTypeV1"
+          },
+          "config": {
+            "$ref": "#/components/schemas/DataSourceConfigV1"
+          },
+          "credentialType": {
+            "$ref": "#/components/schemas/DataSourceCredentialTypeV1"
+          },
+          "credentials": {
+            "$ref": "#/components/schemas/DataSourceCredentialsV1"
+          },
+          "dataSourceType": {
+            "$ref": "#/components/schemas/DataSourceTypeV1"
+          },
+          "description": {
+            "description": "Description of the Data Source",
+            "example": "My Data Source",
+            "type": "string"
+          },
+          "name": {
+            "description": "User given name of the Data Source",
+            "example": "data-source-name",
+            "type": "string"
+          },
+          "permissions": {
+            "$ref": "#/components/schemas/DataSourcePermissionsV1"
+          }
+        },
+        "required": [
+          "name",
+          "dataSourceType",
+          "authType",
+          "credentialType",
+          "credentials",
+          "config",
+          "permissions"
+        ],
+        "type": "object"
+      },
       "NewDatasetRwV1": {
         "properties": {
           "description": {
@@ -2234,6 +2921,45 @@
         },
         "required": [
           "name"
+        ],
+        "type": "object"
+      },
+      "NewEndpointV1": {
+        "properties": {
+          "endpointName": {
+            "description": "Valid name of the endpoint",
+            "example": "completions",
+            "type": "string"
+          },
+          "endpointPermissions": {
+            "$ref": "#/components/schemas/EndpointPermissionsDtoV1"
+          },
+          "endpointType": {
+            "description": "Type of the endpoint",
+            "example": "llm/v1/completions",
+            "type": "string"
+          },
+          "modelConfig": {
+            "$ref": "#/components/schemas/ModelConfigV1"
+          },
+          "modelName": {
+            "description": "Name of the model",
+            "example": "gpt-4",
+            "type": "string"
+          },
+          "modelProvider": {
+            "description": "Provider of the model",
+            "example": "openai",
+            "type": "string"
+          }
+        },
+        "required": [
+          "endpointName",
+          "endpointType",
+          "endpointPermissions",
+          "modelProvider",
+          "modelName",
+          "modelConfig"
         ],
         "type": "object"
       },
@@ -2342,6 +3068,97 @@
           "Private"
         ],
         "type": "string"
+      },
+      "NewHardwareTierFlagsV1": {
+        "description": "Boolean flags for creating a new hardware tier",
+        "properties": {
+          "isDataAnalystTier": {
+            "default": false,
+            "type": "boolean"
+          },
+          "isDefault": {
+            "default": false,
+            "type": "boolean"
+          },
+          "isDefaultForModelApi": {
+            "type": "boolean"
+          },
+          "isGlobal": {
+            "default": true,
+            "type": "boolean"
+          },
+          "isModelApiTier": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "default": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "NewHardwareTierV1": {
+        "properties": {
+          "availabilityZones": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "centsPerMinute": {
+            "description": "Cost per minute of using this hardware tier as defined by an Admin.",
+            "format": "double",
+            "type": "number"
+          },
+          "computeClusterRestrictions": {
+            "$ref": "#/components/schemas/HardwareTierComputeClusterRestrictionsV1"
+          },
+          "dataPlaneId": {
+            "type": "string"
+          },
+          "flags": {
+            "$ref": "#/components/schemas/NewHardwareTierFlagsV1"
+          },
+          "gpuConfiguration": {
+            "$ref": "#/components/schemas/HardwareTierGpuConfigurationV1"
+          },
+          "id": {
+            "example": "small-k8s",
+            "type": "string"
+          },
+          "maxSimultaneousExecutions": {
+            "type": "integer"
+          },
+          "name": {
+            "example": "My-HardwareTier",
+            "type": "string"
+          },
+          "nodePool": {
+            "type": "string"
+          },
+          "overProvisioning": {
+            "$ref": "#/components/schemas/HardwareTierOverProvisioningV1"
+          },
+          "podCustomization": {
+            "$ref": "#/components/schemas/HardwareTierPodCustomizationV1"
+          },
+          "resources": {
+            "$ref": "#/components/schemas/HardwareTierResourcesV1"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "resources",
+          "nodePool"
+        ],
+        "type": "object"
       },
       "NewJobV1": {
         "properties": {
@@ -2778,6 +3595,24 @@
         ],
         "type": "object"
       },
+      "PaginatedDataSourceEnvelopeV1": {
+        "properties": {
+          "dataSources": {
+            "items": {
+              "$ref": "#/components/schemas/DataSourceEnvelopeV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          }
+        },
+        "required": [
+          "dataSources",
+          "metadata"
+        ],
+        "type": "object"
+      },
       "PaginatedDatasetRwEnvelopeV1": {
         "properties": {
           "datasets": {
@@ -2882,6 +3717,24 @@
         },
         "required": [
           "goals",
+          "metadata"
+        ],
+        "type": "object"
+      },
+      "PaginatedHardwareTierEnvelopeV1": {
+        "properties": {
+          "hardwareTiers": {
+            "items": {
+              "$ref": "#/components/schemas/HardwareTierV1"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/PaginatedMetadataV1"
+          }
+        },
+        "required": [
+          "hardwareTiers",
           "metadata"
         ],
         "type": "object"
@@ -3666,8 +4519,8 @@
         },
         "description": "A map of key -> value",
         "example": {
-          "key": "foo",
-          "value": 1
+          "key": 1,
+          "key2": 100.4
         },
         "type": "object"
       },
@@ -3703,6 +4556,7 @@
         "type": "object"
       },
       "RegisteredModelRequestingUserAccessV1": {
+        "description": "Describes the operations that the requesting user has permission to do with this model.",
         "properties": {
           "canEditModel": {
             "description": "True if the requesting user can update this model",
@@ -3856,8 +4710,8 @@
         },
         "description": "A map of key -> value",
         "example": {
-          "key": "foo",
-          "value": "bar"
+          "key": "value",
+          "key2": "anothervalue"
         },
         "type": "object"
       },
@@ -3898,8 +4752,7 @@
             "$ref": "#/components/schemas/RegisteredModelProjectSummaryV1"
           },
           "requestingUserAccess": {
-            "$ref": "#/components/schemas/RegisteredModelRequestingUserAccessV1",
-            "description": "Describes the operations that the requesting user has permission to do with this model."
+            "$ref": "#/components/schemas/RegisteredModelRequestingUserAccessV1"
           },
           "tags": {
             "$ref": "#/components/schemas/RegisteredModelTagsV1"
@@ -4625,6 +5478,50 @@
         ],
         "type": "object"
       },
+      "UpdatedEndpointPermissionsV1": {
+        "properties": {
+          "isEveryoneAllowed": {
+            "description": "If the endpoint is accessible by everyone",
+            "type": "boolean"
+          },
+          "userIds": {
+            "description": "User IDs that can access this endpoint",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "UpdatedEndpointV1": {
+        "properties": {
+          "endpointName": {
+            "description": "Valid name of the endpoint",
+            "example": "completions-1",
+            "type": "string"
+          },
+          "endpointType": {
+            "description": "Type of the endpoint",
+            "example": "llm/v1/completions",
+            "type": "string"
+          },
+          "modelConfig": {
+            "$ref": "#/components/schemas/ModelConfigV1"
+          },
+          "modelName": {
+            "description": "Name of the model",
+            "example": "gpt-3.5",
+            "type": "string"
+          },
+          "modelProvider": {
+            "description": "Provider of the model",
+            "example": "openai",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "UpdatedRegisteredModelReviewV1": {
         "properties": {
           "notes": {
@@ -4761,10 +5658,351 @@
   "info": {
     "description": "Domino Public API Endpoints",
     "title": "Domino Public API",
-    "version": "5.9.1"
+    "version": "5.10.1"
   },
   "openapi": "3.0.3",
   "paths": {
+    "/api/aigateway/v1/endpoints": {
+      "get": {
+        "description": "Get all active LLM endpoints accessible by the user",
+        "operationId": "getAllGatewayEndpoints",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AIGatewayEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get all active LLM endpoints accessible by the user",
+        "tags": [
+          "AIGateway"
+        ]
+      },
+      "post": {
+        "description": "Create a new a endpoint",
+        "operationId": "createGatewayEndpoint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewEndpointV1"
+              }
+            }
+          },
+          "description": "Details of the new endpoint to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a new endpoint",
+        "tags": [
+          "AIGateway"
+        ]
+      }
+    },
+    "/api/aigateway/v1/endpoints/{endpointName}": {
+      "delete": {
+        "description": "Delete a endpoint by name",
+        "operationId": "deleteGatewayEndpointByName",
+        "parameters": [
+          {
+            "description": "Name of the endpoint to delete",
+            "in": "path",
+            "name": "endpointName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Delete a endpoint by name",
+        "tags": [
+          "AIGateway"
+        ]
+      },
+      "get": {
+        "description": "Get a endpoint by name (returns endpoint if user has access and endpoint is active)",
+        "operationId": "getGatewayEndpointByName",
+        "parameters": [
+          {
+            "description": "Name of the endpoint to get",
+            "in": "path",
+            "name": "endpointName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of input tokens sent to the endpoint",
+            "in": "query",
+            "name": "numInputTokens",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get a endpoint by name",
+        "tags": [
+          "AIGateway"
+        ]
+      },
+      "patch": {
+        "description": "Update a endpoint by name (change endpoint name, endpoint type, model name, model provider, or model config)",
+        "operationId": "updateGatewayEndpointByName",
+        "parameters": [
+          {
+            "description": "Name of the endpoint to update details for",
+            "in": "path",
+            "name": "endpointName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatedEndpointV1"
+              }
+            }
+          },
+          "description": "Updated endpoint details",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update a endpoint by name",
+        "tags": [
+          "AIGateway"
+        ]
+      }
+    },
+    "/api/aigateway/v1/endpoints/{endpointName}/permissions": {
+      "get": {
+        "description": "Get permissions for a endpoint by name",
+        "operationId": "getGatewayEndpointPermissionsByName",
+        "parameters": [
+          {
+            "description": "Name of the endpoint to get permissions for",
+            "in": "path",
+            "name": "endpointName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointPermissionsDtoV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get permissions for a endpoint by name",
+        "tags": [
+          "AIGateway"
+        ]
+      },
+      "patch": {
+        "description": "Update permissions for a endpoint by name (add or remove user IDs, or change isEveryoneAllowed)",
+        "operationId": "updateGatewayEndpointPermissionsByName",
+        "parameters": [
+          {
+            "description": "Name of the endpoint to update permissions for",
+            "in": "path",
+            "name": "endpointName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatedEndpointPermissionsV1"
+              }
+            }
+          },
+          "description": "Updated endpoint permissions",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointPermissionsDtoV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update permissions for a endpoint by name",
+        "tags": [
+          "AIGateway"
+        ]
+      }
+    },
     "/api/cost/v1/allocation": {
       "get": {
         "description": "Retrieve cost allocation",
@@ -4997,6 +6235,525 @@
           }
         },
         "summary": "Get the asset cost over a time window",
+        "tags": [
+          "Cost"
+        ]
+      }
+    },
+    "/api/cost/v1/athenaConfigs": {
+      "put": {
+        "description": "Set AWS Billing API Configuration",
+        "operationId": "setAthenaConfigs",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AthenaBillingConfigsV1"
+              }
+            }
+          },
+          "description": "AWS Billing API Config",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AthenaBillingConfigsV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Set AWS Billing API Configuration",
+        "tags": [
+          "Cost"
+        ]
+      }
+    },
+    "/api/cost/v1/billingtagSettings": {
+      "/api/cost/v1/billingtagSettings/mode": {
+        "get": {
+          "description": "Get mode setting of the billing tags",
+          "operationId": "getBillingTagMode",
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/BillingTagsModeEnvelopeV1"
+                  }
+                }
+              },
+              "description": "Success"
+            },
+            "400": {
+              "$ref": "#/components/responses/400"
+            },
+            "401": {
+              "$ref": "#/components/responses/401"
+            },
+            "403": {
+              "$ref": "#/components/responses/403"
+            },
+            "404": {
+              "$ref": "#/components/responses/404"
+            },
+            "500": {
+              "$ref": "#/components/responses/500"
+            }
+          },
+          "summary": "Get mode setting of the billing tags",
+          "tags": [
+            "BillingTagSettings"
+          ]
+        },
+        "put": {
+          "description": "Update mode setting of the billing tags",
+          "operationId": "updateBillingTagMode",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingTagsModeV1"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/BillingTagsModeEnvelopeV1"
+                  }
+                }
+              },
+              "description": "Success"
+            },
+            "400": {
+              "$ref": "#/components/responses/400"
+            },
+            "401": {
+              "$ref": "#/components/responses/401"
+            },
+            "403": {
+              "$ref": "#/components/responses/403"
+            },
+            "404": {
+              "$ref": "#/components/responses/404"
+            },
+            "500": {
+              "$ref": "#/components/responses/500"
+            }
+          },
+          "summary": "Update mode setting of the billing tags",
+          "tags": [
+            "BillingTagSettings"
+          ]
+        }
+      },
+      "/api/cost/v1/billingtagSettings/notifications": {
+        "get": {
+          "description": "Get notifications setting of the billing tags",
+          "operationId": "getBillingTagNotification",
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/BillingTagsNotificationsEnvelopeV1"
+                  }
+                }
+              },
+              "description": "Success"
+            },
+            "400": {
+              "$ref": "#/components/responses/400"
+            },
+            "401": {
+              "$ref": "#/components/responses/401"
+            },
+            "403": {
+              "$ref": "#/components/responses/403"
+            },
+            "404": {
+              "$ref": "#/components/responses/404"
+            },
+            "500": {
+              "$ref": "#/components/responses/500"
+            }
+          },
+          "summary": "Get notifications setting of the billing tags",
+          "tags": [
+            "BillingTagSettings"
+          ]
+        },
+        "put": {
+          "description": "Update notifications setting of the billing tags",
+          "operationId": "updateBillingTagNotification",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingTagsNotificationsV1"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/BillingTagsNotificationsEnvelopeV1"
+                  }
+                }
+              },
+              "description": "Success"
+            },
+            "400": {
+              "$ref": "#/components/responses/400"
+            },
+            "401": {
+              "$ref": "#/components/responses/401"
+            },
+            "403": {
+              "$ref": "#/components/responses/403"
+            },
+            "404": {
+              "$ref": "#/components/responses/404"
+            },
+            "500": {
+              "$ref": "#/components/responses/500"
+            }
+          },
+          "summary": "Update notifications setting of the billing tags",
+          "tags": [
+            "BillingTagSettings"
+          ]
+        }
+      },
+      "get": {
+        "description": "Get  billing tags setting",
+        "operationId": "getBillingTagSettings",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingTagsSettingsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get  billing tags setting",
+        "tags": [
+          "BillingTagSettings"
+        ]
+      },
+      "put": {
+        "description": "Update billing tags setting",
+        "operationId": "updateBillingTagSettings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BillingTagsSettingsV1"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingTagsSettingsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update billing tags setting",
+        "tags": [
+          "BillingTagSettings"
+        ]
+      }
+    },
+    "/api/cost/v1/billingtags": {
+      "get": {
+        "description": "Get billing codes that a user can see.",
+        "operationId": "getBillingTags",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingTagsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get usable billing codes",
+        "tags": [
+          "BillingTag"
+        ]
+      },
+      "post": {
+        "description": "Upsert billing codes.",
+        "operationId": "upsertBillingTags",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewBillingTagsV1"
+              }
+            }
+          },
+          "description": "Billing codes to upsert",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingTagsEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Upsert billing codes",
+        "tags": [
+          "BillingTag"
+        ]
+      }
+    },
+    "/api/cost/v1/billingtags/{tag}": {
+      "delete": {
+        "description": "Deactivate a  billing tag.",
+        "operationId": "deactivateBillingTag",
+        "parameters": [
+          {
+            "description": "tag of the  billing tag to archive",
+            "in": "path",
+            "name": "tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingTagEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Deactivate billing tag",
+        "tags": [
+          "BillingTag"
+        ]
+      },
+      "get": {
+        "description": "Get billing tag by tag name.",
+        "operationId": "getBillingTagByName",
+        "parameters": [
+          {
+            "description": "tag of the  billing tag to archive",
+            "in": "path",
+            "name": "tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingTagEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get billing tag by tag name",
+        "tags": [
+          "BillingTag"
+        ]
+      }
+    },
+    "/api/cost/v1/licenseKey": {
+      "put": {
+        "description": "Add kubecost license key",
+        "operationId": "addKubecostLicenseKey",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KubecostLicenseV1"
+              }
+            }
+          },
+          "description": "Kubecost License Key",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KubecostLicenseResponseV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Add kubecost license key",
         "tags": [
           "Cost"
         ]
@@ -5805,11 +7562,11 @@
     },
     "/api/datasource/v1/audit": {
       "get": {
-        "description": "Gets data source audit data given filter input parameters",
+        "description": "Gets Data Source audit data given filter input parameters",
         "operationId": "getDataSourceAuditData",
         "parameters": [
           {
-            "description": "Datasource IDs to query audit data for",
+            "description": "Data Source IDs to query audit data for",
             "in": "query",
             "name": "dataSourceIds",
             "required": false,
@@ -5821,7 +7578,7 @@
             }
           },
           {
-            "description": "Datasource names to query audit data for",
+            "description": "Data Source names to query audit data for",
             "in": "query",
             "name": "dataSourceNames",
             "required": false,
@@ -5895,7 +7652,278 @@
             "$ref": "#/components/responses/500"
           }
         },
-        "summary": "Get DataSource Audit Data",
+        "summary": "Get Data Source Audit Data",
+        "tags": [
+          "DataSource"
+        ]
+      }
+    },
+    "/api/datasource/v1/datasources": {
+      "get": {
+        "description": "Get Data Sources that a user has access to based on Data Source permissions and input filters",
+        "operationId": "getAccessibleAndActiveDataSources",
+        "parameters": [
+          {
+            "description": "Names of the Data Sources to get",
+            "in": "query",
+            "name": "dataSourceNames",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "How many Data Sources from the start to skip, sorted by descending ID order. Defaults to 0",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of Data Sources to fetch. Defaults to 10",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedDataSourceEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get all active Data Source the user has access to",
+        "tags": [
+          "DataSource"
+        ]
+      },
+      "post": {
+        "description": "Create a Data Source",
+        "operationId": "createDataSource",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewDataSourceV1"
+              }
+            }
+          },
+          "description": "Data Source to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSourceEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a Data Source",
+        "tags": [
+          "DataSource"
+        ]
+      }
+    },
+    "/api/datasource/v1/datasources/{dataSourceId}": {
+      "delete": {
+        "description": "Delete Data Source with specified ID. Requires Data Source ownership privileges",
+        "operationId": "deleteDataSource",
+        "parameters": [
+          {
+            "description": "ID of Data Source to delete",
+            "example": "62604702b7e5d347dbe7a909",
+            "in": "path",
+            "name": "dataSourceId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSourceEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Delete Data Source with specified ID",
+        "tags": [
+          "DataSource"
+        ]
+      },
+      "get": {
+        "description": "Gets Data Source by ID. Requires access to Data Source",
+        "operationId": "getDataSource",
+        "parameters": [
+          {
+            "description": "ID of Data Source to get",
+            "example": "62604702b7e5d347dbe7a909",
+            "in": "path",
+            "name": "dataSourceId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSourceEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get Data Source by ID",
+        "tags": [
+          "DataSource"
+        ]
+      },
+      "patch": {
+        "description": "Update Data Source with specified ID. If the current user is not an admin, then only their individual credentials are updated. Otherwise, the shared credentials are updated. If updating a Starburst-powered Data Source, please remember to restart the Starburst cluster in the UI for the changes to take effect. Requires Data Source management privileges",
+        "operationId": "updateDataSource",
+        "parameters": [
+          {
+            "description": "ID of Data Source to update",
+            "example": "62604702b7e5d347dbe7a909",
+            "in": "path",
+            "name": "dataSourceId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DataSourceUpdateV1"
+              }
+            }
+          },
+          "description": "Users and projects to add and remove",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSourceEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update Data Source with specified ID",
         "tags": [
           "DataSource"
         ]
@@ -6222,6 +8250,258 @@
         "summary": "Get an environment",
         "tags": [
           "Environments"
+        ]
+      }
+    },
+    "/api/hardwaretiers/v1/hardwaretiers": {
+      "get": {
+        "description": "Get all hardware tiers. Required permissions: `ViewHardwareTiers`",
+        "operationId": "getAllHardwareTiers",
+        "parameters": [
+          {
+            "description": "How many hardware tiers from the start to skip. Defaults to 0.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "How many hardware tiers to fetch. Defaults to 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Whether to include archived hardware tiers. Defaults to false.",
+            "in": "query",
+            "name": "includeArchived",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedHardwareTierEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get all hardware tiers",
+        "tags": [
+          "HardwareTier"
+        ]
+      },
+      "post": {
+        "description": "Create a hardware tier. Required permissions: `ManageHardwareTiers`",
+        "operationId": "createHardwareTier",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewHardwareTierV1"
+              }
+            }
+          },
+          "description": "Hardware tier to create",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HardwareTierEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Create a hardware tier",
+        "tags": [
+          "HardwareTier"
+        ]
+      },
+      "put": {
+        "description": "Update a hardware tier. Required permissions: `ManageHardwareTiers`",
+        "operationId": "updateHardwareTier",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HardwareTierV1"
+              }
+            }
+          },
+          "description": "Updated hardware tier",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HardwareTierEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Update a hardware tier",
+        "tags": [
+          "HardwareTier"
+        ]
+      }
+    },
+    "/api/hardwaretiers/v1/hardwaretiers/{hardwareTierId}": {
+      "delete": {
+        "description": "Archive a hardware tier by Id. Required permissions: `ManageHardwareTiers`",
+        "operationId": "archiveHardwareTier",
+        "parameters": [
+          {
+            "description": "Id of hardwareTier to archive",
+            "in": "path",
+            "name": "hardwareTierId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HardwareTierEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Archive a hardware tier",
+        "tags": [
+          "HardwareTier"
+        ]
+      },
+      "get": {
+        "description": "Get a hardware tier by Id. Required permissions: `ViewHardwareTiers`",
+        "operationId": "getHardwareTierById",
+        "parameters": [
+          {
+            "description": "Id of hardwareTier to retrieve",
+            "in": "path",
+            "name": "hardwareTierId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HardwareTierEnvelopeV1"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Get a hardware tier by Id",
+        "tags": [
+          "HardwareTier"
         ]
       }
     },
@@ -6618,15 +8898,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "description": "Id of project for the goal",
-            "in": "query",
-            "name": "projectId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -6835,7 +9106,7 @@
     },
     "/api/metricAlerts/v1": {
       "post": {
-        "description": "Send a metric out of range alert for a monitored model. Required Permissions: None",
+        "description": "Send a metric out of range alert for a monitored model. Required Permissions: `ViewMonitoringResults`",
         "operationId": "sendMetricAlert",
         "requestBody": {
           "content": {
@@ -6876,7 +9147,7 @@
     },
     "/api/metricValues/v1": {
       "post": {
-        "description": "Log metric values. Required Permissions: None",
+        "description": "Log metric values. Required Permissions: `RegisterMonitoringDataset`",
         "operationId": "logMetricValues",
         "requestBody": {
           "content": {
@@ -6917,7 +9188,7 @@
     },
     "/api/metricValues/v1/{modelMonitoringId}/{metric}": {
       "get": {
-        "description": "Retrieve metric values. Required Permissions: None",
+        "description": "Retrieve metric values. Required Permissions: `UpdateMonitoringSettings`",
         "operationId": "retrieveMetricValues",
         "parameters": [
           {
@@ -7604,69 +9875,10 @@
         ]
       }
     },
-    "/api/projects/beta/projects/{projectId}/copy-project": {
-      "post": {
-        "description": "Create a new project by copying an existing project and providing optional overrides. Specify a git repository to link to the copied project or copy the original project's git repository for the copied project.",
-        "operationId": "copyProjectBeta",
-        "parameters": [
-          {
-            "description": "Project ID",
-            "in": "path",
-            "name": "projectId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CopyProjectSpecBeta"
-              }
-            }
-          },
-          "description": "Information needed in order to copy a project.",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProjectCopyResultEnvelopeV1"
-                }
-              }
-            },
-            "description": "Success"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "summary": "Create a new project by copying an existing project and providing optional overrides. Deprecated.",
-        "tags": [
-          "Projects"
-        ]
-      }
-    },
     "/api/projects/beta/projects/{projectId}/files/{commitId}/{path}/content": {
       "get": {
         "description": "Return the raw contents of a file in a project at given commit.",
-        "operationId": "getProjectFileContents",
+        "operationId": "getProjectFileContentsDeprecated",
         "parameters": [
           {
             "description": "Id of the project to return files for",
@@ -7726,7 +9938,7 @@
             "$ref": "#/components/responses/500"
           }
         },
-        "summary": "Returns the contents of a file",
+        "summary": "Returns the contents of a file (deprecated, use v1 endpoint instead)",
         "tags": [
           "ProjectsFiles"
         ]
@@ -8058,6 +10270,75 @@
         "summary": "Create a new project by copying an existing project and providing optional overrides.",
         "tags": [
           "Projects"
+        ]
+      }
+    },
+    "/api/projects/v1/projects/{projectId}/files/{commitId}/{path}/content": {
+      "get": {
+        "description": "Return the raw contents of a file in a project at given commit.",
+        "operationId": "getProjectFileContents",
+        "parameters": [
+          {
+            "description": "Id of the project to return files for",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Id of a commit in the project repository to list files from",
+            "in": "path",
+            "name": "commitId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path in the project's repository to the file. It must be url-encoded and is case-sensitive.",
+            "example": "nested%2Ffolder%2Ffile.ext",
+            "in": "path",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Success. It returns a stream of data with the file content, specifying the appropriate\nmedia type based on the file extension in a best-effort basis.\n",
+            "x-domino-binary-stream": true
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "summary": "Returns the contents of a file",
+        "tags": [
+          "ProjectsFiles"
         ]
       }
     },
@@ -8786,7 +11067,7 @@
             }
           },
           {
-            "description": "List of columns for ordering search results, which can include model name and last updated timestamp with an optional ���DESC��� or ���ASC��� annotation, where ���ASC��� is the default. Tiebreaks are done by model name ASC.",
+            "description": "List of columns for ordering search results, which can include model name and last updated timestamp with an optional \"DESC\" or \"ASC\" annotation, where \"ASC\" is the default. Tiebreaks are done by model name ASC.",
             "in": "query",
             "name": "orderBy",
             "schema": {
@@ -9042,7 +11323,7 @@
             }
           },
           {
-            "description": "List of columns for ordering search results, which can include model name and last updated timestamp with an optional ���DESC��� or ���ASC��� annotation, where ���ASC��� is the default.",
+            "description": "List of columns for ordering search results, which can include model name and last updated timestamp with an optional \"DESC\" or \"ASC\" annotation, where \"ASC\" is the default.",
             "in": "query",
             "name": "orderBy",
             "schema": {
@@ -10151,102 +12432,6 @@
           "Users"
         ]
       }
-    },
-    "/athenaConfigs": {
-      "put": {
-        "description": "Set AWS Billing API Configuration",
-        "operationId": "setAthenaConfigs",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AthenaBillingConfigsV1"
-              }
-            }
-          },
-          "description": "AWS Billing API Config",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AthenaBillingConfigsV1"
-                }
-              }
-            },
-            "description": "Success"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "summary": "Set AWS Billing API Configuration",
-        "tags": [
-          "Cost"
-        ]
-      }
-    },
-    "/licenseKey": {
-      "put": {
-        "description": "Add kubecost license key",
-        "operationId": "addKubecostLicenseKey",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/KubecostLicenseV1"
-              }
-            }
-          },
-          "description": "Kubecost License Key",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KubecostLicenseResponseV1"
-                }
-              }
-            },
-            "description": "Success"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "summary": "Add kubecost license key",
-        "tags": [
-          "Cost"
-        ]
-      }
     }
   },
   "security": [
@@ -10274,6 +12459,9 @@
       "name": "Environments"
     },
     {
+      "name": "HardwareTier"
+    },
+    {
       "name": "Jobs"
     },
     {
@@ -10283,7 +12471,10 @@
       "name": "Projects"
     },
     {
-      "name": "Registered Models"
+      "name": "RegisteredModels"
+    },
+    {
+      "name": "AIGateway"
     },
     {
       "name": "Users"


### PR DESCRIPTION
Post-processed (the nice word for it) the internal and public OpenAPI JSON files after downloading them from Domino 5.10.1. Sorted and formatted the files for easier comparison. Repeated the process of capitalizing the same enum values for the public API that @kjhoerr did for a previous release.