### PR TITLE
domino-openapi.json: Fix allowedOperations enum

### DIFF
--- a/src/conf/domino-openapi.json
+++ b/src/conf/domino-openapi.json
@@ -23965,7 +23965,7 @@
                 "ProjectSearchPreview",
                 "BrowseReadFiles",
                 "EditTags",
-                "RunLauncher",
+                "RunLaunchers",
                 "ViewRuns"
               ],
               "type": "string"


### PR DESCRIPTION
Fixing a spec-did-not-change (but did internally) issue:

Domino 5.9.1
![image-y3grheurj3y6ikay7fw8wobyeh](https://github.com/user-attachments/assets/5950f2b6-82a4-44f8-a5af-e8c84d224ead)

Domino 5.11.1
![image-panomqfxw38zuq1kh3po8rdpye](https://github.com/user-attachments/assets/43dca65b-b42f-41bb-b350-037b9b5e80cf)
