### PR TITLE
Fix Domino 5.9 interoperation

### DIFF
--- a/src/conf/domino-openapi.json
+++ b/src/conf/domino-openapi.json
@@ -23965,6 +23965,7 @@
                 "ProjectSearchPreview",
                 "BrowseReadFiles",
                 "EditTags",
+                "RunLauncher",
                 "RunLaunchers",
                 "ViewRuns"
               ],


### PR DESCRIPTION
Add RunLauncher enum to allowedOperations as appears in Domino 5.9