### PR TITLE
Add slimapi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.32</version>
+            <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
-                            <inputSpec>${project.basedir}/src/conf/domino-openapi.json</inputSpec>
+                            <inputSpec>${project.basedir}/src/conf/slim-api.json</inputSpec>
                             <skipValidateSpec>true</skipValidateSpec>
                             <skipIfSpecIsUnchanged>true</skipIfSpecIsUnchanged>
                             <generatorName>java</generatorName>

--- a/src/conf/slim-api.json
+++ b/src/conf/slim-api.json
@@ -1,0 +1,118 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "description": "This API provides access to select Domino functions available in Domino's non-public API.\nTo authenticate your requests, include your API Key (which you can find on your account page) with the header X-Domino-Api-Key.\n",
+        "title": "Domino Data Lab API v4",
+        "version": "4.0.0"
+      },
+    "paths": {
+      "/projects/{projectId}/useableEnvironments": {
+        "get": {
+          "operationId": "getUseableEnvironments",
+          "parameters": [
+            {
+              "description": "Id of the project",
+              "in": "path",
+              "name": "projectId",
+              "required": true,
+              "schema": {
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/domino.projects.api.UseableProjectEnvironmentsDTO"
+                  }
+                }
+              },
+              "description": "success"
+            },
+            "403": {
+              "$ref": "#/components/responses/Forbidden"
+            },
+            "404": {
+              "$ref": "#/components/responses/NotFound"
+            },
+            "500": {
+              "$ref": "#/components/responses/InternalError"
+            }
+          },
+          "summary": "gets the list of Environments that this Project can use",
+          "tags": [
+            "Projects"
+          ]
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "domino.projects.api.UseableProjectEnvironmentsDTO": {
+          "type": "object",
+          "properties": {
+            "environments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Environment"
+              }
+            }
+          }
+        },
+        "Environment": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "responses": {
+        "Forbidden": {
+          "description": "Forbidden"
+        },
+        "NotFound": {
+          "description": "Not Found"
+        },
+        "InternalError": {
+          "description": "Internal Server Error"
+        }
+      },
+      "securitySchemes": {
+        "BearerAuthentication": {
+          "in": "header",
+          "name": "Authorization",
+          "type": "apiKey"
+        },
+        "DominoApiKey": {
+          "in": "header",
+          "name": "X-Domino-Api-Key",
+          "type": "apiKey"
+        }
+      }
+    },
+    "security": [
+        {
+          "BearerAuthentication": []
+        },
+        {
+          "DominoApiKey": []
+        }
+      ],
+    "servers": [
+        {
+          "url": "/v4"
+        }
+      ],
+    "tags": []    
+  }

--- a/src/conf/slim-api.json
+++ b/src/conf/slim-api.json
@@ -1,474 +1,4687 @@
 {
-    "openapi": "3.0.0",
-    "info": {
-        "description": "This API provides access to select Domino functions available in Domino's non-public API.\nTo authenticate your requests, include your API Key (which you can find on your account page) with the header X-Domino-Api-Key.\n",
-        "title": "Domino Data Lab API v4",
-        "version": "4.0.0"
-      },
-    "paths": {
-
-      "/admin/supportbundle/{executionId}": {
-        "get": {
-          "operationId": "getExecutionSupportBundle",
-          "parameters": [
-            {
-              "in": "path",
-              "name": "executionId",
-              "required": true,
-              "schema": {
-                "pattern": "^[0-9a-f]{24}$",
-                "type": "string"
+  "openapi": "3.0.0",
+  "info": {
+    "description": "This API provides access to select Domino functions available in Domino's non-public API.\nTo authenticate your requests, include your API Key (which you can find on your account page) with the header X-Domino-Api-Key.\n",
+    "title": "Domino Data Lab API v4",
+    "version": "4.0.0"
+  },
+  "paths": {
+    "/admin/supportbundle/{executionId}": {
+      "get": {
+        "operationId": "getExecutionSupportBundle",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "executionId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": { "format": "binary", "type": "string" }
               }
-            }
-          ],
-          "responses": {
-            "200": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "format": "binary",
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "success"
             },
-            "400": {
-              "$ref": "#/components/responses/BadRequest"
-            },
-            "401": {
-              "$ref": "#/components/responses/Unauthorized"
-            },
-            "403": {
-              "$ref": "#/components/responses/Forbidden"
-            },
-            "500": {
-              "$ref": "#/components/responses/InternalError"
-            }
+            "description": "success"
           },
-          "summary": "Gets a zipfile containing useful information about an executionId, FIXME should this path be /executions/executionId/supportbundle",
-          "tags": [
-            "Admin"
-          ]
-        }
-      },
-      "/datasetrw/snapshot/{snapshotId}/download-local/{taskKey}": {
-        "get": {
-          "operationId": "downloadArchiveToLocal",
-          "parameters": [
-            {
-              "description": "Id of the dataset snapshot where files are downloaded from",
-              "in": "path",
-              "name": "snapshotId",
-              "required": true,
-              "schema": {
-                "pattern": "^[0-9a-f]{24}$",
-                "type": "string"
-              }
-            },
-            {
-              "description": "Key of the download task to be polled",
-              "in": "path",
-              "name": "taskKey",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "format": "binary",
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "success"
-            },
-            "400": {
-              "$ref": "#/components/responses/BadRequest"
-            },
-            "401": {
-              "$ref": "#/components/responses/Unauthorized"
-            },
-            "403": {
-              "$ref": "#/components/responses/Forbidden"
-            },
-            "500": {
-              "$ref": "#/components/responses/InternalError"
-            }
-          },
-          "summary": "Download archive file from Domino to local",
-          "tags": [
-            "DatasetRw"
-          ]
-        }
-      },      
-      "/datasetrw/snapshot/{snapshotId}/file/raw": {
-        "get": {
-          "operationId": "getFileRaw",
-          "parameters": [
-            {
-              "description": "snapshot ID",
-              "in": "path",
-              "name": "snapshotId",
-              "required": true,
-              "schema": {
-                "pattern": "^[0-9a-f]{24}$",
-                "type": "string"
-              }
-            },
-            {
-              "description": "path of file to get raw content for",
-              "in": "query",
-              "name": "path",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            },
-            {
-              "description": "whether endpoint is used for download",
-              "in": "query",
-              "name": "download",
-              "required": false,
-              "schema": {
-                "nullable": true,
-                "type": "boolean"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "content": {
-                "application/octet-stream": {
-                  "schema": {
-                    "format": "binary",
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "success"
-            },
-            "400": {
-              "$ref": "#/components/responses/BadRequest"
-            },
-            "401": {
-              "$ref": "#/components/responses/Unauthorized"
-            },
-            "403": {
-              "$ref": "#/components/responses/Forbidden"
-            },
-            "500": {
-              "$ref": "#/components/responses/InternalError"
-            }
-          },
-          "summary": "Get snapshot file raw content at specified path",
-          "tags": [
-            "DatasetRw"
-          ]
-        }
-      },      
-      "/datasource/audit/download/runs": {
-        "get": {
-          "operationId": "downloadDataSourceAuditDataInRuns",
-          "parameters": [
-            {
-              "description": "the ids of the runs to query datasources from",
-              "in": "query",
-              "name": "runIds",
-              "required": true,
-              "schema": {
-                "items": {
-                  "pattern": "^[0-9a-f]{24}$",
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            {
-              "description": "if true output will be json file, else txt",
-              "in": "query",
-              "name": "jsonFile",
-              "required": false,
-              "schema": {
-                "nullable": true,
-                "type": "boolean"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "content": {
-                "application/jsonl": {
-                  "schema": {
-                    "format": "binary",
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "success"
-            },
-            "400": {
-              "$ref": "#/components/responses/BadRequest"
-            },
-            "401": {
-              "$ref": "#/components/responses/Unauthorized"
-            },
-            "403": {
-              "$ref": "#/components/responses/Forbidden"
-            },
-            "500": {
-              "$ref": "#/components/responses/InternalError"
-            }
-          },
-          "summary": "Download DataSource Audit Data accessed in Domino runs",
-          "tags": [
-            "DataSource"
-          ]
-        }
-      },
-      "/datasource/audit/download": {
-        "get": {
-          "operationId": "downloadDataSourceAuditData",
-          "parameters": [
-            {
-              "description": "if true output will be json file, else txt",
-              "in": "query",
-              "name": "jsonFile",
-              "required": false,
-              "schema": {
-                "nullable": true,
-                "type": "boolean"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "content": {
-                "application/octet-stream": {
-                  "schema": {
-                    "format": "binary",
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "success"
-            },
-            "400": {
-              "$ref": "#/components/responses/BadRequest"
-            },
-            "401": {
-              "$ref": "#/components/responses/Unauthorized"
-            },
-            "403": {
-              "$ref": "#/components/responses/Forbidden"
-            },
-            "500": {
-              "$ref": "#/components/responses/InternalError"
-            }
-          },
-          "summary": "Download DataSource Audit Data for past 6 months",
-          "tags": [
-            "DataSource"
-          ]
-        }
-      },      
-      "/modelManager/{modelVersionId}/logs": {
-        "get": {
-          "operationId": "downloadLogs",
-          "parameters": [
-            {
-              "in": "path",
-              "name": "modelVersionId",
-              "required": true,
-              "schema": {
-                "pattern": "^[0-9a-f]{24}$",
-                "type": "string"
-              }
-            },
-            {
-              "in": "query",
-              "name": "startMillis",
-              "required": true,
-              "schema": {
-                "format": "int64",
-                "type": "integer"
-              }
-            },
-            {
-              "in": "query",
-              "name": "endMillis",
-              "required": true,
-              "schema": {
-                "format": "int64",
-                "type": "integer"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "content": {
-                "application/x-ndjson": {
-                  "schema": {
-                    "format": "binary",
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "success"
-            },
-            "401": {
-              "$ref": "#/components/responses/Unauthorized"
-            },
-            "500": {
-              "$ref": "#/components/responses/InternalError"
-            }
-          },
-          "summary": "download logs for a model for a given time range",
-          "tags": [
-            "ModelManager"
-          ]
-        }
-      },      
-      "/projects/{projectId}/useableEnvironments": {
-        "get": {
-          "operationId": "getUseableEnvironments",
-          "parameters": [
-            {
-              "description": "Id of the project",
-              "in": "path",
-              "name": "projectId",
-              "required": true,
-              "schema": {
-                "pattern": "^[0-9a-f]{24}$",
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/domino.projects.api.UseableProjectEnvironmentsDTO"
-                  }
-                }
-              },
-              "description": "success"
-            },
-            "403": {
-              "$ref": "#/components/responses/Forbidden"
-            },
-            "404": {
-              "$ref": "#/components/responses/NotFound"
-            },
-            "500": {
-              "$ref": "#/components/responses/InternalError"
-            }
-          },
-          "summary": "gets the list of Environments that this Project can use",
-          "tags": [
-            "Projects"
-          ]
-        }
-      }      
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Gets a zipfile containing useful information about an executionId, FIXME should this path be /executions/executionId/supportbundle",
+        "tags": ["Admin"]
+      }
     },
-    "components": {
-      "schemas": {
-        "domino.projects.api.UseableProjectEnvironmentsDTO": {
-          "type": "object",
-          "properties": {
-            "environments": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Environment"
+    "/datasetrw/snapshot/{snapshotId}/download-local/{taskKey}": {
+      "get": {
+        "operationId": "downloadArchiveToLocal",
+        "parameters": [
+          {
+            "description": "Id of the dataset snapshot where files are downloaded from",
+            "in": "path",
+            "name": "snapshotId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Key of the download task to be polled",
+            "in": "path",
+            "name": "taskKey",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": { "format": "binary", "type": "string" }
               }
-            }
-          }
-        },
-        "Environment": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string"
             },
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            }
-          }
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
         },
-        "Error": {
-          "type": "object",
-          "properties": {
-            "message": {
-              "type": "string"
-            }
+        "summary": "Download archive file from Domino to local",
+        "tags": ["DatasetRw"]
+      }
+    },
+    "/datasetrw/snapshot/{snapshotId}/file/raw": {
+      "get": {
+        "operationId": "getFileRaw",
+        "parameters": [
+          {
+            "description": "snapshot ID",
+            "in": "path",
+            "name": "snapshotId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "path of file to get raw content for",
+            "in": "query",
+            "name": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "description": "whether endpoint is used for download",
+            "in": "query",
+            "name": "download",
+            "required": false,
+            "schema": { "nullable": true, "type": "boolean" }
           }
-        }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": { "format": "binary", "type": "string" }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Get snapshot file raw content at specified path",
+        "tags": ["DatasetRw"]
+      }
+    },
+    "/datasource/audit/download/runs": {
+      "get": {
+        "operationId": "downloadDataSourceAuditDataInRuns",
+        "parameters": [
+          {
+            "description": "the ids of the runs to query datasources from",
+            "in": "query",
+            "name": "runIds",
+            "required": true,
+            "schema": {
+              "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+              "type": "array"
+            }
+          },
+          {
+            "description": "if true output will be json file, else txt",
+            "in": "query",
+            "name": "jsonFile",
+            "required": false,
+            "schema": { "nullable": true, "type": "boolean" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/jsonl": {
+                "schema": { "format": "binary", "type": "string" }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Download DataSource Audit Data accessed in Domino runs",
+        "tags": ["DataSource"]
+      }
+    },
+    "/datasource/audit/download": {
+      "get": {
+        "operationId": "downloadDataSourceAuditData",
+        "parameters": [
+          {
+            "description": "if true output will be json file, else txt",
+            "in": "query",
+            "name": "jsonFile",
+            "required": false,
+            "schema": { "nullable": true, "type": "boolean" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": { "format": "binary", "type": "string" }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Download DataSource Audit Data for past 6 months",
+        "tags": ["DataSource"]
+      }
+    },
+    "/modelManager/{modelVersionId}/logs": {
+      "get": {
+        "operationId": "downloadLogs",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "modelVersionId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "in": "query",
+            "name": "startMillis",
+            "required": true,
+            "schema": { "format": "int64", "type": "integer" }
+          },
+          {
+            "in": "query",
+            "name": "endMillis",
+            "required": true,
+            "schema": { "format": "int64", "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/x-ndjson": {
+                "schema": { "format": "binary", "type": "string" }
+              }
+            },
+            "description": "success"
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "download logs for a model for a given time range",
+        "tags": ["ModelManager"]
+      }
+    },
+    "/projects/{projectId}/useableEnvironments": {
+      "get": {
+        "operationId": "getUseableEnvironments",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.UseableProjectEnvironmentsDTO"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "gets the list of Environments that this Project can use",
+        "tags": ["Projects"]
+      }
+    },
+    "/accounts/{userId}/gitcredentials": {
+      "get": {
+        "operationId": "getGitCredentials",
+        "parameters": [
+          {
+            "description": "User id for retrieving git credentials",
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.server.account.api.GitCredentialAccessorDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "retrieves git credentials for the given user",
+        "tags": ["Git Credentials"]
       },
-      "responses": {
-        "Forbidden": {
-          "description": "Forbidden"
-        },
-        "NotFound": {
-          "description": "Not Found"
-        },
-        "InternalError": {
-          "description": "Internal Server Error"
-        },
-        "BadRequest": {
-          "description": "Bad Request",
+      "post": {
+        "operationId": "addGitCredential",
+        "parameters": [
+          {
+            "description": "User id for adding git credential",
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Error"
+                "$ref": "#/components/schemas/domino.server.account.api.GitCredentialDto"
               }
             }
-          }
+          },
+          "description": "Git credential",
+          "required": true
         },
-        "Unauthorized": {
-          "description": "Unauthorized",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.server.account.api.GitCredentialAccessorDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "add git credential",
+        "tags": ["Git Credentials"]
+      }
+    },
+    "/accounts/{userId}/gitcredentials/{credentialId}": {
+      "delete": {
+        "operationId": "deleteGitCredential",
+        "parameters": [
+          {
+            "description": "User id for deleting git credential",
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Id of the git credential to delete",
+            "in": "path",
+            "name": "credentialId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.server.account.api.GitCredentialAccessorDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "delete git credential",
+        "tags": ["Git Credentials"]
+      }
+    },
+    "/datamount/projects/{projectId}": {
+      "delete": {
+        "operationId": "removeProject",
+        "parameters": [
+          {
+            "description": "Project id to remove from data mount",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "data mount id from which to remove the project",
+            "in": "query",
+            "name": "datamountId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.datamount.api.DataMountDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Remove project",
+        "tags": ["DataMount"]
+      },
+      "get": {
+        "operationId": "findDataMountsByProject",
+        "parameters": [
+          {
+            "description": "project id",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.datamount.api.DataMountDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Find data mounts by project",
+        "tags": ["DataMount"]
+      },
+      "post": {
+        "operationId": "addProject",
+        "parameters": [
+          {
+            "description": "project id to add to data mounts",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "data mount id's to add to the project",
+            "in": "query",
+            "name": "datamountIds",
+            "required": true,
+            "schema": {
+              "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.datamount.api.DataMountDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Add project to data mounts",
+        "tags": ["DataMount"]
+      }
+    },
+    "/datasetrw": {
+      "post": {
+        "operationId": "createDataset",
+        "parameters": [],
+        "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Error"
+                "$ref": "#/components/schemas/domino.datasetrw.web.CreateDatasetRequest"
               }
             }
+          },
+          "description": "dataset spec to persist",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwViewDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Deprecated - Use the /layout/complete endpoint with the workFlowID \"CreateDataset\" or use the public create endpoint. Create dataset",
+        "tags": ["DatasetRw"]
+      }
+    },
+    "/datasetrw/{projectId}/shared/{datasetId}": {
+      "delete": {
+        "operationId": "removeSharedDatasetRwEntry",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Dataset ID",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.datasetrw.api.SharedDatasetRwEntryDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Removes shared dataset from project",
+        "tags": ["DatasetRw"]
+      },
+      "post": {
+        "operationId": "addSharedDatasetRwEntry",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Dataset ID",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.datasetrw.api.SharedDatasetRwEntryDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Add shared dataset to project",
+        "tags": ["DatasetRw"]
+      }
+    },
+    "/datasetrw/dataset/{datasetId}/grants": {
+      "get": {
+        "operationId": "getDatasetGrants",
+        "parameters": [
+          {
+            "description": "Dataset ID",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwGrantDetails"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "gets dataset's current dataset's grants details",
+        "tags": ["DatasetRw"]
+      },
+      "put": {
+        "operationId": "updateDatasetGrants",
+        "parameters": [
+          {
+            "description": "Dataset ID",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.datasetrw.web.UpdateDatasetGrantsRequest"
+              }
+            }
+          },
+          "description": "Request body with updated set of RwGrants",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwGrant"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "updates a dataset's rwGrants",
+        "tags": ["DatasetRw"]
+      }
+    },
+    "/datasetrw/datasets/{datasetId}": {
+      "get": {
+        "operationId": "getDataset",
+        "parameters": [
+          {
+            "description": "Dataset ID",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Lookup dataset by id",
+        "tags": ["DatasetRw"]
+      }
+    },
+    "/datasetrw/datasets-v2": {
+      "get": {
+        "operationId": "getDatasetsV2",
+        "parameters": [
+          {
+            "description": "boolean to request project level info",
+            "in": "query",
+            "name": "includeProjectInfo",
+            "required": false,
+            "schema": { "nullable": true, "type": "boolean" }
+          },
+          {
+            "description": "boolean to request whether principal has access within a project",
+            "in": "query",
+            "name": "includeHasProjectAccess",
+            "required": false,
+            "schema": { "nullable": true, "type": "boolean" }
+          },
+          {
+            "description": "minimum dataset rw permission to check for",
+            "in": "query",
+            "name": "minimumPermission",
+            "required": false,
+            "schema": { "nullable": true, "type": "string" }
+          },
+          {
+            "description": "project IDs to exclude datasets from",
+            "in": "query",
+            "name": "projectIdsToExclude",
+            "required": false,
+            "schema": {
+              "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          {
+            "description": "project IDs to search datasets from",
+            "in": "query",
+            "name": "projectIdsToInclude",
+            "required": false,
+            "schema": {
+              "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+              "nullable": true,
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwInfoDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Get Datasets",
+        "tags": ["DatasetRw"]
+      }
+    },
+    "/datasetrw/files/{snapshotId}": {
+      "get": {
+        "operationId": "getFilesInSnapshot",
+        "parameters": [
+          {
+            "description": "snapshot ID",
+            "in": "path",
+            "name": "snapshotId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "subPath to get files at",
+            "in": "query",
+            "name": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwSnapshotFilesViewDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Get snapshot files at specified path",
+        "tags": ["DatasetRw"]
+      }
+    },
+    "/datasetrw/mounts-v2/{projectId}/shared": {
+      "get": {
+        "operationId": "getSharedDatasetProjectMountsV2",
+        "parameters": [
+          {
+            "description": "Project ID",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "minimum dataset rw permission to check for",
+            "in": "query",
+            "name": "minimumPermission",
+            "required": false,
+            "schema": { "nullable": true, "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwProjectMountDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Get shared mounts in a project",
+        "tags": ["DatasetRw"]
+      }
+    },
+    "/datasetrw/snapshot/{snapshotId}": {
+      "delete": {
+        "operationId": "deleteDatasetSnapshot",
+        "parameters": [
+          {
+            "description": "Snapshot ID",
+            "in": "path",
+            "name": "snapshotId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwSnapshotDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Delete Snapshot",
+        "tags": ["DatasetRw"]
+      },
+      "get": {
+        "operationId": "getSnapshot",
+        "parameters": [
+          {
+            "description": "Id of the snapshot",
+            "in": "path",
+            "name": "snapshotId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwSnapshotSummaryDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Retrieves the specified snapshot",
+        "tags": ["DatasetRw"]
+      },
+      "put": {
+        "operationId": "updateDatasetSnapshotStatus",
+        "parameters": [
+          {
+            "description": "Id of the dataset snapshot to be updated",
+            "in": "path",
+            "name": "snapshotId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.datasetrw.web.UpdateSnapshotStatusRequest"
+              }
+            }
+          },
+          "description": "JSON object with information describing the new status",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwSnapshotDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Update a dataset snapshot's status",
+        "tags": ["DatasetRw"]
+      }
+    },
+    "/datasetrw/snapshots/{datasetId}": {
+      "get": {
+        "operationId": "getSnapshots",
+        "parameters": [
+          {
+            "description": "Dataset ID",
+            "in": "path",
+            "name": "datasetId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwSnapshotDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Get snapshots in dataset",
+        "tags": ["DatasetRw"]
+      }
+    },
+    "/datasource/{dataSourceId}/projects/{projectId}": {
+      "delete": {
+        "operationId": "removeProjectFromDataSource",
+        "parameters": [
+          {
+            "description": "Data source Id",
+            "in": "path",
+            "name": "dataSourceId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Project Id",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.datasource.api.DataSourceDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Remove project from data source",
+        "tags": ["DataSource"]
+      },
+      "post": {
+        "operationId": "addProjectToDataSource",
+        "parameters": [
+          {
+            "description": "Data source Id",
+            "in": "path",
+            "name": "dataSourceId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Project Id",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.datasource.api.DataSourceDto"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Add project to data source",
+        "tags": ["DataSource"]
+      }
+    },
+    "/gateway/projects": {
+      "get": {
+        "operationId": "listProjects",
+        "parameters": [
+          {
+            "description": "The relationship between the current user and the projects to be returned",
+            "in": "query",
+            "name": "relationship",
+            "required": true,
+            "schema": {
+              "enum": [
+                "Collaborating",
+                "Popular",
+                "OwnedAndCollaborating",
+                "Suggested",
+                "Owned"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "include projects that are completed",
+            "in": "query",
+            "name": "showCompleted",
+            "required": false,
+            "schema": { "default": true, "type": "boolean" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.server.projects.api.ProjectGatewaySummary"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Retrieves projects for the Project List UI, ordered from most to least recently updated",
+        "tags": ["Gateway", "Projects"]
+      }
+    },
+    "/gateway/projects/findProjectByOwnerAndName": {
+      "get": {
+        "operationId": "findProjectByOwnerAndName",
+        "parameters": [
+          {
+            "description": "Username of the Owner",
+            "in": "query",
+            "name": "ownerName",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "description": "Name of the Project",
+            "in": "query",
+            "name": "projectName",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.server.projects.api.ProjectGatewayOverview"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Retrieves a project for the Project Overview UI",
+        "tags": ["Gateway"]
+      }
+    },
+    "/gateway/users/projectsDependencyGraph": {
+      "get": {
+        "operationId": "projectsDependencyGraph",
+        "parameters": [
+          {
+            "description": "Owner username of the project, if dependency graph is being requested for a specific project.",
+            "in": "query",
+            "name": "ownerUsername",
+            "required": false,
+            "schema": { "nullable": true, "type": "string" }
+          },
+          {
+            "description": "Project name for which a dependency graph is being requested. When not provided, the dependency graph is for all projects for the current user.",
+            "in": "query",
+            "name": "projectName",
+            "required": false,
+            "schema": { "nullable": true, "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.nucleus.gateway.users.models.ProjectsDependencyGraph"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Retrieves projects dependency graph for a user, and optionally for a specific project",
+        "tags": ["Gateway", "Users"]
+      }
+    },
+    "/jobs/{jobId}": {
+      "get": {
+        "operationId": "getJob",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.jobs.interface.Job"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Gets a job",
+        "tags": ["Jobs"]
+      }
+    },
+    "/jobs/{jobId}/logsWithProblemSuggestions": {
+      "get": {
+        "operationId": "getLogsWithProblemSuggestions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Types of logs:\n * `console` - This is the default if the value is not provided. All logs lines displayed in the job's runtime environment.\n * `stdout` - Log lines displayed in the stderr of the job's runtime environment.\n * `stderr` - Log lines displayed in the stderr of the job's runtime environment.\n * `stdoutstderr` - Interleaved stdout and stderr.\n * `prepareoutput` - Log lines generated by the environment preparing the job.\n",
+            "in": "query",
+            "name": "logType",
+            "required": false,
+            "schema": {
+              "default": "console",
+              "enum": [
+                "console",
+                "stdout",
+                "stderr",
+                "stdoutstderr",
+                "prepareoutput"
+              ],
+              "example": "console  |  stdout  |  stderr  |  stdoutstderr  |  prepareoutput",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max number of log lines to fetch. Will be overridden by the configuration's limit if this value exceeds the configuration's limit, or if this value is not provided.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": { "default": 10000, "type": "number" }
+          },
+          {
+            "description": "The index of the current body of logs to start fetching from. 0 by default and typically won't be used for a timestamp-based offset log fetching strategy.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": { "default": 0, "type": "number" }
+          },
+          {
+            "description": "The epoch time in nanoseconds to start fetching from, such as \"1543538813745986325\". \"0\" by default and will typically be used for a timestamp-based offset log fetching strategy.",
+            "in": "query",
+            "name": "latestTimeNano",
+            "required": false,
+            "schema": {
+              "default": "0",
+              "example": "1543538813745986325",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.jobs.interface.LogsWithProblemSuggestion"
+                }
+              }
+            },
+            "description": "Scenarios:<br>\nIf the problem  detector detects no problem, then the client should expect\n  * a `LogsWithProblemSuggestion` object with only logs\n\nIf the problem  detector detects the problem, then the client should expect\n  * a `LogsWithProblemSuggestion` object with logs with problem suggestions\n"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Get the suggestion when problem occurs in a job along with the logs",
+        "tags": ["LogsWithProblemSuggestion"]
+      }
+    },
+    "/jobs/{jobId}/name": {
+      "post": {
+        "operationId": "updateJob",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.jobs.web.UpdateJobName"
+              }
+            }
+          },
+          "description": "JSON object with information for new name",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.jobs.interface.Job"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Update name for job",
+        "tags": ["Jobs"]
+      }
+    },
+    "/jobs/restart": {
+      "post": {
+        "operationId": "restartJob",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.jobs.web.JobRestartOperationRequest"
+              }
+            }
+          },
+          "description": "JSON object with information for restarting the Job",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.jobs.interface.Job"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "409": { "$ref": "#/components/responses/Relogin" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Restart a Job",
+        "tags": ["Jobs"]
+      }
+    },
+    "/jobs/start": {
+      "post": {
+        "operationId": "startJob",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.jobs.web.StartJobRequest"
+              }
+            }
+          },
+          "description": "JSON object with information for starting the Job"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.jobs.interface.Job"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "409": { "$ref": "#/components/responses/Relogin" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Starts a new Job",
+        "tags": ["Jobs"]
+      }
+    },
+    "/jobs/stop": {
+      "post": {
+        "operationId": "stopJob",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.jobs.web.JobStopOperationRequest"
+              }
+            }
+          },
+          "description": "JSON object with information for stopping the Job",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.jobs.interface.Job"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Stop a Job",
+        "tags": ["Jobs"]
+      }
+    },
+    "/projectManagement/{jobId}/linkJobToGoal": {
+      "post": {
+        "operationId": "linkJobToGoal",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projectManagement.web.LinkJobToGoalRequest"
+              }
+            }
+          },
+          "description": "JSON object with information for linking goal to a job",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projectManagement.api.ResponseMessage"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "409": {
+            "$ref": "#/components/responses/ProjectManagementErrorResponse"
+          },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Link job to goal",
+        "tags": ["ProjectManagement"]
+      }
+    },
+    "/projectManagement/{projectId}/goals": {
+      "get": {
+        "operationId": "getProjectGoals",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.projects.api.ProjectGoal"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "409": {
+            "$ref": "#/components/responses/ProjectManagementErrorResponse"
+          },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Get project goals",
+        "tags": ["ProjectManagement"]
+      },
+      "post": {
+        "operationId": "getFilteredProjectGoals",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projectManagement.web.FilterProjectGoals"
+              }
+            }
+          },
+          "description": "JSON object with data to filter project goals",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.projects.api.ProjectGoal"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "409": {
+            "$ref": "#/components/responses/ProjectManagementErrorResponse"
+          },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Get project goals",
+        "tags": ["ProjectManagement"]
+      }
+    },
+    "/projects": {
+      "post": {
+        "operationId": "createProject",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.nucleus.project.models.NewProject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.nucleus.project.models.Project"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "creates a project",
+        "tags": ["Projects"]
+      }
+    },
+    "/projects/{projectId}": {
+      "delete": {
+        "operationId": "archiveProjectById",
+        "parameters": [
+          {
+            "description": "Id of the project to archive",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "success" },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "archive an project by id",
+        "tags": ["Projects"]
+      },
+      "get": {
+        "operationId": "getProjectSummary",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectSummary"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "gets the summary for this given projectId",
+        "tags": ["Projects"]
+      }
+    },
+    "/projects/{projectId}/collaborators": {
+      "get": {
+        "operationId": "getProjectCollaborators",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Return only users and org members.",
+            "in": "query",
+            "name": "getUsers",
+            "required": false,
+            "schema": { "nullable": true, "type": "boolean" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.common.user.Person"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Retrieves all of the collaborators in a project",
+        "tags": ["Projects"]
+      },
+      "post": {
+        "operationId": "addCollaborator",
+        "parameters": [
+          {
+            "description": "Id of the project to add collaborator to",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.nucleus.project.models.Collaborator"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.nucleus.project.models.Collaborator"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "adds a user or organization to Project as a collaborator",
+        "tags": ["Projects"]
+      }
+    },
+    "/projects/{projectId}/collaborators/{collaboratorId}": {
+      "delete": {
+        "operationId": "removeCollaborator",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Id of the collaborator to remove from the project",
+            "in": "path",
+            "name": "collaboratorId",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "success" },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "remove a collaborator from a Project",
+        "tags": ["Projects"]
+      }
+    },
+    "/projects/{projectId}/environmentVariables": {
+      "get": {
+        "operationId": "getProjectEnvironmentVariables",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.common.models.EnvironmentVariable"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "retrieves the specified project's environment variables",
+        "tags": ["Projects"]
+      },
+      "post": {
+        "operationId": "upsertProjectEnvironmentVariable",
+        "parameters": [
+          {
+            "description": "Id of the project to add environment variables",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.common.models.EnvironmentVariable"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.common.models.EnvironmentVariable"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "sets the specified project's environment variables",
+        "tags": ["Projects"]
+      }
+    },
+    "/projects/{projectId}/gitRepositories": {
+      "get": {
+        "operationId": "getGitRepos",
+        "parameters": [
+          {
+            "description": "Id of the project to get the repositories from",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.projects.api.repositories.GitRepositoryDTO"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "gets git repositories for a project",
+        "tags": ["Projects"]
+      },
+      "post": {
+        "operationId": "addGitRepo",
+        "parameters": [
+          {
+            "description": "Id of the project to add the repository to",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.repositories.GitRepositoryDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.repositories.GitRepositoryDTO"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "adds a git repository to a project",
+        "tags": ["Projects"]
+      }
+    },
+    "/projects/{projectId}/gitRepositories/{repositoryId}": {
+      "delete": {
+        "operationId": "archiveGitRepo",
+        "parameters": [
+          {
+            "description": "Id of the project to archive the repository from",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Id of the repository to archive",
+            "in": "path",
+            "name": "repositoryId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "success" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "archives a git repository from a project",
+        "tags": ["Projects"]
+      },
+      "patch": {
+        "operationId": "editGitRepo",
+        "parameters": [
+          {
+            "description": "Id of the project to get the repository from",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Id of the repository being edited",
+            "in": "path",
+            "name": "repositoryId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.repositories.GitRepositoryDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": { "description": "success" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "edits a git repository",
+        "tags": ["Projects"]
+      }
+    },
+    "/projects/{projectId}/gitRepositories/{repositoryId}/ref": {
+      "put": {
+        "operationId": "updateGitRepositoryDefaultRef",
+        "parameters": [
+          {
+            "description": "Id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Id of the repository being queried. You can use \"_\" to refer to the project's mainRepository.",
+            "in": "path",
+            "name": "repositoryId",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.projects.api.repositories.ReferenceDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": { "description": "success" },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "update the default ref for a repository",
+        "tags": ["Projects", "Git"]
+      }
+    },
+    "/projects/{projectId}/goal/{goalId}/markComplete": {
+      "post": {
+        "operationId": "markProjectGoalComplete",
+        "parameters": [
+          {
+            "description": "Domino id of the project",
+            "in": "path",
+            "name": "projectId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          },
+          {
+            "description": "Domino id of the goal",
+            "in": "path",
+            "name": "goalId",
+            "required": true,
+            "schema": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.projects.api.ProjectGoal"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Mark project goal complete",
+        "tags": ["Projects"]
+      }
+    },
+    "/runs/recent": {
+      "get": {
+        "operationId": "listRecentRuns",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.common.run.interfaces.RunMonolithDTO"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "retrieves list of active and recently completed runs",
+        "tags": ["Runs"]
+      }
+    },
+    "/scheduledruns": {
+      "get": {
+        "operationId": "listScheduledRuns",
+        "parameters": [
+          { "in": "query", "name": "userId", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.scheduledjob.api.LegacyScheduledRunDTO"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "retrieves list of scheduled run definitions for a given user id",
+        "tags": ["Scheduled Runs"]
+      }
+    },
+    "/users": {
+      "get": {
+        "operationId": "listUsers",
+        "parameters": [
+          {
+            "description": "Optional list of user identifiers to select the previously known users",
+            "in": "query",
+            "name": "userId",
+            "required": false,
+            "schema": {
+              "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          {
+            "description": "Optional filter for an exact user name",
+            "in": "query",
+            "name": "userName",
+            "required": false,
+            "schema": { "nullable": true, "type": "string" }
+          },
+          {
+            "description": "Optional filter for a user name (returns usernames starting with this query)",
+            "in": "query",
+            "name": "query",
+            "required": false,
+            "schema": { "nullable": true, "type": "string" }
+          },
+          {
+            "in": "query",
+            "name": "listOnlyUsers",
+            "required": false,
+            "schema": { "nullable": true, "type": "boolean" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/domino.common.user.Person"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "retrieves a list of users",
+        "tags": ["Users"]
+      },
+      "post": {
+        "operationId": "createUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/domino.common.user.CreateUserRequest"
+              }
+            }
+          },
+          "description": "Create user request",
+          "required": true
+        },
+        "responses": {
+          "201": { "description": "success" },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "Create a new user",
+        "tags": ["Users"]
+      }
+    },
+    "/users/environmentVariables": {
+      "delete": {
+        "operationId": "deleteUserEnvironmentVariables",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.common.models.EnvironmentVariables"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "deletes all of the specified user's environment variables",
+        "tags": ["Users"]
+      },
+      "get": {
+        "operationId": "listUserEnvironmentVariables",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.common.models.EnvironmentVariables"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "retrieves the specified user's environment variables",
+        "tags": ["Users"]
+      },
+      "put": {
+        "operationId": "setUserEnvironmentVariables",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": { "type": "string" },
+                "type": "object"
+              }
+            }
+          },
+          "description": "The user environment variables",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.common.models.EnvironmentVariables"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "set the specified user's environment variables",
+        "tags": ["Users"]
+      }
+    },
+    "/users/self": {
+      "get": {
+        "operationId": "getCurrentUser",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/domino.common.user.Person"
+                }
+              }
+            },
+            "description": "success"
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        },
+        "summary": "retrieves the current user",
+        "tags": ["Users"]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "domino.projects.api.UseableProjectEnvironmentsDTO": {
+        "type": "object",
+        "properties": {
+          "environments": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Environment" }
           }
         }
       },
-      "securitySchemes": {
-        "BearerAuthentication": {
-          "in": "header",
-          "name": "Authorization",
-          "type": "apiKey"
+      "domino.projectManagement.web.ErrorResponse": {
+        "properties": {
+          "code": {
+            "description": "Error code",
+            "format": "int32",
+            "type": "integer"
+          },
+          "message": {
+            "description": "Error message received from external service (ex jira)",
+            "type": "string"
+          }
         },
-        "DominoApiKey": {
-          "in": "header",
-          "name": "X-Domino-Api-Key",
-          "type": "apiKey"
+        "required": ["message", "code"],
+        "type": "object"
+      },
+      "Environment": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "description": { "type": "string" }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": { "message": { "type": "string" } }
+      },
+      "domino.server.account.api.GitCredentialDto": { "properties": {} },
+      "domino.server.account.api.GitCredentialAccessorDto": {
+        "properties": {
+          "domain": { "type": "string" },
+          "fingerprint": { "type": "string" },
+          "gitServiceProvider": {
+            "enum": [
+              "github",
+              "gitlab",
+              "githubEnterprise",
+              "unknown",
+              "gitlabEnterprise",
+              "bitbucket",
+              "bitbucketServer"
+            ],
+            "type": "string"
+          },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "name": { "type": "string" },
+          "protocol": { "type": "string" }
+        },
+        "required": [
+          "id",
+          "name",
+          "gitServiceProvider",
+          "domain",
+          "fingerprint",
+          "protocol"
+        ]
+      },
+      "domino.datamount.api.DataMountDto": {
+        "properties": {
+          "dataPlanes": {
+            "items": {
+              "$ref": "#/components/schemas/domino.dataplane.DataPlaneDto"
+            },
+            "type": "array"
+          },
+          "description": { "nullable": true, "type": "string" },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "isPublic": { "type": "boolean" },
+          "isRegistered": { "type": "boolean" },
+          "mountPath": { "type": "string" },
+          "name": { "type": "string" },
+          "projects": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "type": "array"
+          },
+          "projectsInfo": {
+            "items": {
+              "$ref": "#/components/schemas/domino.datamount.api.DataMountProjectInfoDto"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "pvId": { "type": "string" },
+          "pvcName": { "type": "string" },
+          "readOnly": { "type": "boolean" },
+          "status": { "nullable": true, "type": "string" },
+          "users": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "type": "array"
+          },
+          "volumeType": {
+            "enum": ["Nfs", "Smb", "Efs", "Generic"],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "volumeType",
+          "pvcName",
+          "pvId",
+          "mountPath",
+          "users",
+          "projects",
+          "readOnly",
+          "isPublic",
+          "isRegistered",
+          "dataPlanes"
+        ]
+      },
+      "domino.dataplane.DataPlaneDto": {
+        "properties": {
+          "configuration": {
+            "$ref": "#/components/schemas/domino.dataplane.DataPlaneConfiguration"
+          },
+          "id": { "type": "string" },
+          "isArchived": { "type": "boolean" },
+          "isFileSyncDisabled": { "type": "boolean" },
+          "isHealthy": { "type": "boolean" },
+          "isLocal": { "type": "boolean" },
+          "name": { "type": "string" },
+          "namespace": { "type": "string" },
+          "status": {
+            "$ref": "#/components/schemas/domino.dataplane.DataPlaneStatus"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "namespace",
+          "isLocal",
+          "configuration",
+          "status",
+          "isHealthy",
+          "isArchived",
+          "isFileSyncDisabled"
+        ]
+      },
+      "domino.datamount.api.DataMountProjectInfoDto": {
+        "properties": {
+          "isProjectArchived": { "type": "boolean" },
+          "projectId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "projectName": { "type": "string" },
+          "projectOwnerUsername": { "type": "string" }
+        },
+        "required": [
+          "projectId",
+          "projectName",
+          "projectOwnerUsername",
+          "isProjectArchived"
+        ]
+      },
+      "domino.datasetrw.web.CreateDatasetRequest": {
+        "properties": {
+          "datasetName": { "type": "string" },
+          "description": { "nullable": true, "type": "string" },
+          "grants": {
+            "items": {
+              "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwGrant"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "projectId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "usedForModelMonitoring": { "type": "boolean" }
+        },
+        "required": ["datasetName", "projectId", "usedForModelMonitoring"]
+      },
+      "domino.datasetrw.api.DatasetRwViewDto": {
+        "properties": {
+          "createdTime": { "format": "int64", "type": "integer" },
+          "description": { "nullable": true, "type": "string" },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "name": { "type": "string" },
+          "projectId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "projectName": { "type": "string" },
+          "projectOwner": { "type": "string" },
+          "snapshotIds": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "type": "array"
+          },
+          "tags": {
+            "additionalProperties": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "snapshotIds",
+          "tags",
+          "createdTime",
+          "projectOwner",
+          "projectName"
+        ],
+        "type": "object"
+      },
+      "domino.dataplane.DataPlaneConfiguration": {
+        "properties": {
+          "additionalStorageClass": { "nullable": true, "type": "string" },
+          "address": { "nullable": true, "type": "string" },
+          "dockerRegistryHostname": { "nullable": true, "type": "string" },
+          "dominoApiHostname": { "nullable": true, "type": "string" },
+          "fileSyncDisabled": { "nullable": true, "type": "boolean" },
+          "istioEnabled": { "nullable": true, "type": "boolean" },
+          "rabbitMqAmqpPort": {
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "rabbitMqHostname": { "nullable": true, "type": "string" },
+          "rabbitMqStreamPort": {
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "s3EndpointUrl": { "nullable": true, "type": "string" },
+          "storageClass": { "nullable": true, "type": "string" }
+        }
+      },
+      "domino.dataplane.DataPlaneStatus": {
+        "properties": {
+          "lastHeartbeatTimestamp": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "message": { "type": "string" },
+          "requiresUpgrade": { "type": "boolean" },
+          "state": {
+            "enum": ["Healthy", "Unhealthy", "Error", "Disconnected"],
+            "type": "string"
+          },
+          "version": { "type": "string" }
+        },
+        "required": ["state", "message", "version", "requiresUpgrade"]
+      },
+      "domino.datasetrw.api.DatasetRwGrant": {
+        "properties": {
+          "targetId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "targetRole": {
+            "enum": ["DatasetRwOwner", "DatasetRwEditor", "DatasetRwReader"],
+            "type": "string"
+          }
+        },
+        "required": ["targetId", "targetRole"]
+      },
+      "domino.datasetrw.api.SharedDatasetRwEntryDto": {
+        "properties": {
+          "projectId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "sharedDatasets": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "type": "array"
+          }
+        },
+        "required": ["projectId", "sharedDatasets"]
+      },
+      "domino.datasetrw.web.UpdateDatasetGrantsRequest": {
+        "properties": {
+          "grants": {
+            "items": {
+              "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwGrant"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["grants"]
+      },
+      "domino.datasetrw.api.DatasetRwGrantDetails": {
+        "properties": {
+          "isOrganization": { "type": "boolean" },
+          "targetId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "targetName": { "type": "string" },
+          "targetRole": {
+            "enum": ["DatasetRwOwner", "DatasetRwEditor", "DatasetRwReader"],
+            "type": "string"
+          }
+        },
+        "required": ["targetId", "targetName", "targetRole", "isOrganization"]
+      },
+      "domino.datasetrw.api.DatasetRwDto": {
+        "properties": {
+          "activeROSnapshotCount": {
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "author": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "createdTime": { "format": "int64", "type": "integer" },
+          "dataPlaneIds": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "type": "array"
+          },
+          "datasetPath": { "type": "string" },
+          "description": { "nullable": true, "type": "string" },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "lifecycleStatus": {
+            "enum": [
+              "Pending",
+              "Deleted",
+              "DeletionInProgress",
+              "Failed",
+              "Active",
+              "MarkedForDeletion"
+            ],
+            "type": "string"
+          },
+          "name": { "type": "string" },
+          "ownerUsernames": {
+            "items": { "type": "string" },
+            "nullable": true,
+            "type": "array"
+          },
+          "projectId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "readWriteSnapshotId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "sizeInBytes": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "sizeStatus": {
+            "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwSizeStatus",
+            "enum": ["Active", "Pending"],
+            "nullable": true,
+            "type": "string"
+          },
+          "snapshotIds": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "type": "array"
+          },
+          "statusLastUpdatedBy": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "statusLastUpdatedTime": { "format": "int64", "type": "integer" },
+          "tags": {
+            "additionalProperties": {
+              "pattern": "^[0-9a-f]{24}$",
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "snapshotIds",
+          "tags",
+          "createdTime",
+          "lifecycleStatus",
+          "statusLastUpdatedBy",
+          "statusLastUpdatedTime",
+          "readWriteSnapshotId",
+          "datasetPath"
+        ],
+        "type": "object"
+      },
+      "domino.datasetrw.api.DatasetRwSizeStatus": {
+        "enum": ["Active", "Pending"],
+        "type": "string"
+      },
+      "domino.datasetrw.api.DatasetRwInfoDto": {
+        "properties": {
+          "datasetRwDto": {
+            "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwDto"
+          },
+          "projectInfo": {
+            "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwProjectInfoDto",
+            "nullable": true
+          }
+        },
+        "required": ["datasetRwDto"]
+      },
+      "domino.datasetrw.api.DatasetRwProjectInfoDto": {
+        "properties": {
+          "hasProjectAccess": { "nullable": true, "type": "boolean" },
+          "isProjectArchived": { "type": "boolean" },
+          "projectId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "projectName": { "type": "string" },
+          "projectOwnerUsername": { "type": "string" }
+        },
+        "required": [
+          "projectId",
+          "projectName",
+          "projectOwnerUsername",
+          "isProjectArchived"
+        ]
+      },
+      "domino.datasetrw.api.DatasetRwSnapshotFilesViewDto": {
+        "properties": {
+          "directorySize": { "nullable": true, "type": "string" },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwFileDetailsRowDto"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["rows"]
+      },
+      "domino.datasetrw.api.DatasetRwFileDetailsRowDto": {
+        "properties": {
+          "lastModified": { "format": "int64", "type": "integer" },
+          "name": {
+            "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwFileDetailsDto"
+          },
+          "size": {
+            "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwFileDetailsDto"
+          }
+        },
+        "required": ["name", "size", "lastModified"]
+      },
+      "domino.datasetrw.api.DatasetRwProjectMountDto": {
+        "properties": {
+          "availableVersions": { "format": "int32", "type": "integer" },
+          "dataPlanes": {
+            "items": {
+              "$ref": "#/components/schemas/domino.dataplane.DataPlaneDto"
+            },
+            "type": "array"
+          },
+          "datasetId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "description": { "nullable": true, "type": "string" },
+          "isPartialSize": { "type": "boolean" },
+          "mountPathsForProject": {
+            "items": { "type": "string" },
+            "type": "array"
+          },
+          "name": { "type": "string" },
+          "ownerProjectId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "ownerProjectName": { "type": "string" },
+          "ownerProjectOwnerUsername": { "type": "string" },
+          "ownerUsernames": {
+            "items": { "type": "string" },
+            "nullable": true,
+            "type": "array"
+          },
+          "sizeInBytes": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "sizeStatus": {
+            "enum": ["Active", "Pending"],
+            "nullable": true,
+            "type": "string"
+          },
+          "snapshotId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "storageSize": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "versionNumber": {
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "datasetId",
+          "snapshotId",
+          "name",
+          "ownerProjectOwnerUsername",
+          "ownerProjectName",
+          "isPartialSize",
+          "availableVersions",
+          "mountPathsForProject",
+          "dataPlanes"
+        ]
+      },
+      "domino.datasetrw.api.DatasetRwFileDetailsDto": {
+        "properties": {
+          "fileName": { "nullable": true, "type": "string" },
+          "isDirectory": { "nullable": true, "type": "boolean" },
+          "label": { "type": "string" },
+          "sizeInBytes": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "sortableName": { "nullable": true, "type": "string" },
+          "url": { "nullable": true, "type": "string" }
+        },
+        "required": ["label"]
+      },
+      "domino.datasetrw.web.UpdateSnapshotStatusRequest": {
+        "properties": {
+          "status": {
+            "enum": [
+              "Pending",
+              "Deleted",
+              "DeletionInProgress",
+              "Copying",
+              "Failed",
+              "Active",
+              "MarkedForDeletion"
+            ],
+            "type": "string"
+          }
+        },
+        "required": ["status"]
+      },
+      "domino.datasetrw.api.DatasetRwSnapshotDto": {
+        "properties": {
+          "author": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "creationTime": { "format": "int64", "type": "integer" },
+          "datasetId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "description": { "nullable": true, "type": "string" },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "isPartialSize": { "type": "boolean" },
+          "isReadWrite": { "type": "boolean" },
+          "lastUsedTime": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "lifecycleStatus": {
+            "enum": [
+              "Pending",
+              "Deleted",
+              "DeletionInProgress",
+              "Copying",
+              "Failed",
+              "Active",
+              "MarkedForDeletion"
+            ],
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwResourceDto"
+          },
+          "statusLastUpdatedBy": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "statusLastUpdatedTime": { "format": "int64", "type": "integer" },
+          "storageSize": { "format": "int64", "type": "integer" },
+          "version": { "format": "int32", "type": "integer" }
+        },
+        "required": [
+          "id",
+          "resource",
+          "datasetId",
+          "version",
+          "creationTime",
+          "lifecycleStatus",
+          "statusLastUpdatedBy",
+          "statusLastUpdatedTime",
+          "storageSize",
+          "isPartialSize",
+          "isReadWrite"
+        ]
+      },
+      "domino.datasetrw.api.DatasetRwSnapshotSummaryDto": {
+        "properties": {
+          "authorUsername": { "nullable": true, "type": "string" },
+          "datasetDescription": { "nullable": true, "type": "string" },
+          "isReadWrite": { "type": "boolean" },
+          "snapshot": {
+            "$ref": "#/components/schemas/domino.datasetrw.api.DatasetRwSnapshotDto"
+          }
+        },
+        "required": ["snapshot", "isReadWrite"]
+      },
+      "domino.datasetrw.api.DatasetRwResourceDto": {
+        "properties": {
+          "claimName": { "type": "string" },
+          "resourceId": { "type": "string" },
+          "subDir": { "type": "string" }
+        },
+        "required": ["claimName", "resourceId", "subDir"]
+      },
+      "domino.datasource.api.DataSourceDto": {
+        "properties": {
+          "addedBy": {
+            "additionalProperties": { "type": "string" },
+            "type": "object"
+          },
+          "addedToProjectTimeMap": {
+            "additionalProperties": { "format": "int64", "type": "integer" },
+            "type": "object"
+          },
+          "adminInfo": {
+            "$ref": "#/components/schemas/domino.datasource.api.DataSourceAdminInfoDto"
+          },
+          "authType": {
+            "enum": [
+              "AzureBasic",
+              "Basic",
+              "GCPBasic",
+              "AWSIAMBasic",
+              "AWSIAMBasicNoOverride",
+              "AWSIAMRole",
+              "AWSIAMRoleWithUsername",
+              "OAuth",
+              "PersonalToken",
+              "UserOnly",
+              "BasicOptional",
+              "NoAuth",
+              "ClientIdSecret",
+              "OAuthToken",
+              "APIKey"
+            ],
+            "type": "string"
+          },
+          "config": {
+            "additionalProperties": { "type": "string" },
+            "type": "object"
+          },
+          "dataPlanes": {
+            "items": {
+              "$ref": "#/components/schemas/domino.datasource.api.DataSourceDataPlaneInfo"
+            },
+            "type": "array"
+          },
+          "dataSourcePermissions": {
+            "$ref": "#/components/schemas/domino.datasource.api.DataSourcePermissionsDto"
+          },
+          "dataSourceType": {
+            "enum": [
+              "ADLSConfig",
+              "AzureBlobStorageConfig",
+              "BigQueryConfig",
+              "ClickHouseConfig",
+              "DatabricksConfig",
+              "DB2Config",
+              "DruidConfig",
+              "GCSConfig",
+              "GenericJDBCConfig",
+              "GenericS3Config",
+              "GreenplumConfig",
+              "IgniteConfig",
+              "MariaDBConfig",
+              "MongoDBConfig",
+              "MySQLConfig",
+              "NetezzaConfig",
+              "OracleConfig",
+              "PalantirConfig",
+              "PineconeConfig",
+              "PostgreSQLConfig",
+              "QdrantConfig",
+              "RedshiftConfig",
+              "S3Config",
+              "SAPHanaConfig",
+              "SingleStoreConfig",
+              "SQLServerConfig",
+              "SnowflakeConfig",
+              "SynapseConfig",
+              "TabularS3GlueConfig",
+              "TeradataConfig",
+              "TrinoConfig",
+              "VerticaConfig"
+            ],
+            "type": "string"
+          },
+          "description": { "nullable": true, "type": "string" },
+          "displayName": { "type": "string" },
+          "engineInfo": {
+            "$ref": "#/components/schemas/domino.datasource.api.EngineInfoDto"
+          },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "lastAccessed": {
+            "additionalProperties": { "format": "int64", "type": "integer" },
+            "type": "object"
+          },
+          "lastUpdated": { "format": "int64", "type": "integer" },
+          "lastUpdatedBy": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "name": { "type": "string" },
+          "ownerId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "ownerInfo": {
+            "$ref": "#/components/schemas/domino.datasource.api.DataSourceOwnerInfoDto"
+          },
+          "projectIds": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "type": "array"
+          },
+          "status": {
+            "enum": ["Pending", "Active", "Deleted"],
+            "type": "string"
+          },
+          "useAllDataPlanes": { "type": "boolean" }
+        },
+        "required": [
+          "id",
+          "name",
+          "ownerId",
+          "ownerInfo",
+          "addedBy",
+          "dataSourceType",
+          "config",
+          "dataSourcePermissions",
+          "lastUpdated",
+          "lastUpdatedBy",
+          "lastAccessed",
+          "addedToProjectTimeMap",
+          "projectIds",
+          "adminInfo",
+          "status"
+        ],
+        "type": "object"
+      },
+      "domino.datasource.api.DataSourceAdminInfoDto": {
+        "properties": {
+          "projectIdOwnerUsernameMap": {
+            "additionalProperties": { "type": "string" },
+            "type": "object"
+          },
+          "projectLastActiveMap": {
+            "additionalProperties": { "nullable": true, "type": "string" },
+            "type": "object"
+          },
+          "projectNames": {
+            "additionalProperties": { "type": "string" },
+            "type": "object"
+          }
+        },
+        "required": [
+          "projectNames",
+          "projectIdOwnerUsernameMap",
+          "projectLastActiveMap"
+        ],
+        "type": "object"
+      },
+      "domino.datasource.api.DataSourceDataPlaneInfo": {
+        "properties": {
+          "dataPlaneId": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+        },
+        "required": ["dataPlaneId"]
+      },
+      "domino.datasource.api.DataSourcePermissionsDto": {
+        "properties": {
+          "credentialType": {
+            "enum": ["Individual", "Shared"],
+            "type": "string"
+          },
+          "isEveryone": { "type": "boolean" },
+          "userIds": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "type": "array"
+          }
+        },
+        "required": ["isEveryone", "userIds", "credentialType"]
+      },
+      "domino.datasource.api.EngineInfoDto": {
+        "properties": {
+          "catalogEntryName": { "type": "string" },
+          "engineType": { "enum": ["Domino", "Starburst"], "type": "string" }
+        },
+        "required": ["engineType", "catalogEntryName"]
+      },
+      "domino.datasource.api.DataSourceOwnerInfoDto": {
+        "properties": {
+          "isOwnerAdmin": { "type": "boolean" },
+          "ownerEmail": { "type": "string" },
+          "ownerName": { "type": "string" }
+        },
+        "required": ["ownerName", "ownerEmail", "isOwnerAdmin"]
+      },
+      "domino.server.projects.api.ProjectGatewaySummary": {
+        "properties": {
+          "description": { "type": "string" },
+          "details": {
+            "$ref": "#/components/schemas/domino.server.projects.api.ProjectGatewayOverviewDetails"
+          },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "isPinned": { "nullable": true, "type": "boolean" },
+          "latestResultRunId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "latestResultTimestamp": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "mainGitRepositoryUri": { "nullable": true, "type": "string" },
+          "name": { "type": "string" },
+          "ownerId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "ownerName": { "type": "string" },
+          "projectType": {
+            "enum": ["Analytic", "DataSet", "Template"],
+            "type": "string"
+          },
+          "relationship": {
+            "enum": [
+              "Collaborating",
+              "Popular",
+              "OwnedAndCollaborating",
+              "Suggested",
+              "Owned"
+            ],
+            "type": "string"
+          },
+          "runCounts": {
+            "items": {
+              "$ref": "#/components/schemas/domino.server.projects.api.ProjectGatewayRunCountForType"
+            },
+            "type": "array"
+          },
+          "serviceProvider": {
+            "enum": [
+              "github",
+              "gitlab",
+              "githubEnterprise",
+              "unknown",
+              "gitlabEnterprise",
+              "bitbucket",
+              "bitbucketServer"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "stageId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "status": {
+            "$ref": "#/components/schemas/domino.server.projects.api.ProjectStatus"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/domino.server.projects.api.ProjectGatewayTag"
+            },
+            "type": "array"
+          },
+          "visibility": {
+            "enum": ["Public", "Searchable", "Private"],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "ownerId",
+          "ownerName",
+          "description",
+          "visibility",
+          "tags",
+          "runCounts",
+          "relationship",
+          "projectType",
+          "stageId",
+          "status",
+          "details"
+        ]
+      },
+      "domino.server.projects.api.ProjectGatewayOverviewDetails": {
+        "properties": {
+          "isRestricted": { "nullable": true, "type": "boolean" },
+          "updatedAt": { "format": "date-time", "type": "string" }
+        },
+        "required": ["updatedAt"]
+      },
+      "domino.server.projects.api.ProjectGatewayRunCountForType": {
+        "properties": {
+          "executingCount": { "format": "int32", "type": "integer" },
+          "runType": {
+            "enum": [
+              "Endpoint",
+              "App",
+              "Scheduled",
+              "Launcher",
+              "Batch",
+              "Workspace",
+              "Other",
+              "SSHProxy"
+            ],
+            "type": "string"
+          },
+          "stoppedCount": { "format": "int32", "type": "integer" }
+        },
+        "required": ["runType", "executingCount", "stoppedCount"]
+      },
+      "domino.server.projects.api.ProjectStatus": {
+        "properties": {
+          "blockedReason": { "nullable": true, "type": "string" },
+          "completedMessage": { "nullable": true, "type": "string" },
+          "isBlocked": { "type": "boolean" },
+          "status": { "enum": ["active", "complete"], "type": "string" }
+        },
+        "required": ["status", "isBlocked"]
+      },
+      "domino.server.projects.api.ProjectGatewayTag": {
+        "properties": {
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "isApproved": { "type": "boolean" },
+          "name": { "type": "string" }
+        },
+        "required": ["id", "name", "isApproved"]
+      },
+      "domino.server.projects.api.ProjectGatewayOverview": {
+        "description": "Project Overview entity returned by the API gateway",
+        "properties": {
+          "allowedOperations": {
+            "items": {
+              "enum": [
+                "ChangeProjectSettings",
+                "Run",
+                "Edit",
+                "ViewWorkspaces",
+                "UpdateProjectDescription",
+                "ProjectSearchPreview",
+                "BrowseReadFiles",
+                "EditTags",
+                "RunLauncher",
+                "RunLaunchers",
+                "ViewRuns"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": { "type": "string" },
+          "details": {
+            "$ref": "#/components/schemas/domino.server.projects.api.ProjectGatewayOverviewDetails"
+          },
+          "enabledGitRepositories": {
+            "items": {
+              "$ref": "#/components/schemas/domino.repoman.domain.GitRepository"
+            },
+            "type": "array"
+          },
+          "environmentName": { "type": "string" },
+          "hardwareTierId": { "type": "string" },
+          "hardwareTierName": { "type": "string" },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "lastStageChangeInMillis": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "lastStatusChangeInMillis": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "mainRepository": {
+            "$ref": "#/components/schemas/domino.server.projects.api.MainRepositoryDetails",
+            "id": { "type": "string" },
+            "nullable": true,
+            "serviceProvider": { "type": "string" },
+            "uri": { "type": "string" }
+          },
+          "name": { "type": "string" },
+          "numComments": { "format": "int64", "type": "integer" },
+          "owner": {
+            "$ref": "#/components/schemas/domino.server.projects.api.Owner"
+          },
+          "requestingUserRole": {
+            "enum": [
+              "Admin",
+              "ProjectImporter",
+              "Contributor",
+              "Viewer",
+              "ResultsConsumer",
+              "LauncherUser",
+              "Owner"
+            ],
+            "type": "string"
+          },
+          "runsCountByType": {
+            "items": {
+              "$ref": "#/components/schemas/domino.server.projects.api.ProjectGatewayExecutingRunsByType"
+            },
+            "type": "array"
+          },
+          "stageId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "status": {
+            "$ref": "#/components/schemas/domino.server.projects.api.ProjectStatus"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/domino.server.projects.api.ProjectGatewayTag"
+            },
+            "type": "array"
+          },
+          "templateDetails": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateDetails",
+            "nullable": true
+          },
+          "totalRunTime": {
+            "description": "sum of run times of all executions in the project, in ISO8601 duration format including only seconds and milliseconds",
+            "type": "string"
+          },
+          "updatedAt": { "format": "date-time", "type": "string" },
+          "visibility": {
+            "enum": ["Public", "Searchable", "Private"],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "owner",
+          "description",
+          "hardwareTierName",
+          "hardwareTierId",
+          "environmentName",
+          "allowedOperations",
+          "visibility",
+          "tags",
+          "updatedAt",
+          "numComments",
+          "runsCountByType",
+          "totalRunTime",
+          "stageId",
+          "status",
+          "requestingUserRole"
+        ],
+        "type": "object"
+      },
+      "domino.repoman.domain.GitRepository": {
+        "properties": {
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "isFeatureStore": { "nullable": true, "type": "boolean" },
+          "name": { "type": "string" },
+          "serviceProvider": {
+            "enum": [
+              "github",
+              "gitlab",
+              "githubEnterprise",
+              "unknown",
+              "gitlabEnterprise",
+              "bitbucket",
+              "bitbucketServer"
+            ],
+            "type": "string"
+          },
+          "uriHost": { "type": "string" },
+          "uriPath": { "type": "string" },
+          "uriPort": { "nullable": true, "type": "string" }
+        },
+        "required": ["id", "name", "uriHost", "uriPath", "serviceProvider"]
+      },
+      "domino.server.projects.api.MainRepositoryDetails": {
+        "properties": {
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "serviceProvider": {
+            "enum": [
+              "github",
+              "gitlab",
+              "githubEnterprise",
+              "unknown",
+              "gitlabEnterprise",
+              "bitbucket",
+              "bitbucketServer"
+            ],
+            "type": "string"
+          },
+          "uri": { "type": "string" }
+        },
+        "required": ["uri", "id", "serviceProvider"]
+      },
+      "domino.server.projects.api.Owner": {
+        "properties": {
+          "id": { "nullable": true, "type": "string" },
+          "userName": { "type": "string" }
+        },
+        "required": ["userName"]
+      },
+      "domino.server.projects.api.ProjectGatewayExecutingRunsByType": {
+        "properties": {
+          "count": { "format": "int32", "type": "integer" },
+          "runType": {
+            "enum": [
+              "Endpoint",
+              "App",
+              "Scheduled",
+              "Launcher",
+              "Batch",
+              "Workspace",
+              "Other",
+              "SSHProxy"
+            ],
+            "type": "string"
+          }
+        },
+        "required": ["runType", "count"]
+      },
+      "domino.projects.api.ProjectTemplateDetails": {
+        "properties": {
+          "name": { "type": "string" },
+          "templateId": { "type": "string" },
+          "templateRevisionId": { "nullable": true, "type": "string" },
+          "templateType": {
+            "enum": ["customer", "ecosystem"],
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": ["name", "templateId"]
+      },
+      "domino.nucleus.gateway.users.models.ProjectsDependencyGraph": {
+        "properties": {
+          "nodes": {
+            "items": {
+              "$ref": "#/components/schemas/domino.nucleus.gateway.users.models.ProjectDependencyView"
+            },
+            "type": "array"
+          },
+          "selectedProjectId": {
+            "$ref": "#/components/schemas/domino.common.ProjectId",
+            "nullable": true
+          }
+        },
+        "required": ["nodes"]
+      },
+      "domino.nucleus.gateway.users.models.ProjectDependencyView": {
+        "properties": {
+          "dependencies": {
+            "items": { "$ref": "#/components/schemas/domino.common.ProjectId" },
+            "type": "array"
+          },
+          "projectId": {
+            "$ref": "#/components/schemas/domino.common.ProjectId"
+          },
+          "projectType": {
+            "enum": ["Analytic", "DataSet", "Template"],
+            "type": "string"
+          }
+        },
+        "required": ["projectId", "projectType", "dependencies"]
+      },
+      "domino.common.ProjectId": {
+        "properties": {
+          "ownerUsername": { "type": "string" },
+          "projectName": { "type": "string" }
+        },
+        "required": ["ownerUsername", "projectName"]
+      },
+      "domino.jobs.interface.Job": {
+        "properties": {
+          "commentsCount": { "format": "int32", "type": "integer" },
+          "commitDetails": {
+            "$ref": "#/components/schemas/domino.jobs.interface.CommitDetails"
+          },
+          "computeCluster": {
+            "$ref": "#/components/schemas/domino.jobs.interface.ComputeClusterConfigSpecDto",
+            "nullable": true
+          },
+          "dataPlane": {
+            "$ref": "#/components/schemas/domino.dataplane.DataPlaneDto",
+            "nullable": true
+          },
+          "dependentDatasetMounts": {
+            "items": {
+              "$ref": "#/components/schemas/domino.jobs.interface.DependentDatasetMount"
+            },
+            "type": "array"
+          },
+          "dependentExternalVolumeMounts": {
+            "items": {
+              "$ref": "#/components/schemas/domino.jobs.interface.DependentExternalVolumeMount"
+            },
+            "type": "array"
+          },
+          "dependentProjects": {
+            "items": {
+              "$ref": "#/components/schemas/domino.jobs.interface.DependentProject"
+            },
+            "type": "array"
+          },
+          "dependentRepositories": {
+            "items": {
+              "$ref": "#/components/schemas/domino.jobs.interface.DependentRepository"
+            },
+            "type": "array"
+          },
+          "dominoStats": {
+            "items": {
+              "$ref": "#/components/schemas/domino.jobs.interface.DominoStats"
+            },
+            "type": "array"
+          },
+          "goalIds": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "type": "array"
+          },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "jobRunCommand": { "type": "string" },
+          "mainRepoGitRef": {
+            "$ref": "#/components/schemas/domino.projects.api.repositories.ReferenceDTO",
+            "nullable": true
+          },
+          "number": { "format": "int32", "type": "integer" },
+          "queuedJobHistoryDetails": {
+            "$ref": "#/components/schemas/domino.jobs.interface.QueuedJobHistoryDetails",
+            "nullable": true
+          },
+          "runLauncherId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "snapshotDatasetsOnCompletion": { "type": "boolean" },
+          "stageTime": {
+            "$ref": "#/components/schemas/domino.jobs.interface.StageTime"
+          },
+          "startedBy": {
+            "$ref": "#/components/schemas/domino.jobs.interface.JobStartedBy",
+            "nullable": true
+          },
+          "statuses": {
+            "$ref": "#/components/schemas/domino.jobs.interface.JobStatuses"
+          },
+          "suggestDatasets": { "type": "boolean" },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/domino.jobs.interface.TagApplication"
+            },
+            "type": "array"
+          },
+          "title": { "nullable": true, "type": "string" },
+          "usage": {
+            "$ref": "#/components/schemas/domino.jobs.interface.JobUsageInJob",
+            "nullable": true
+          },
+          "workflowDetails": {
+            "$ref": "#/components/schemas/domino.jobs.interface.WorkflowDetails",
+            "nullable": true
+          }
+        },
+        "required": [
+          "number",
+          "id",
+          "stageTime",
+          "tags",
+          "jobRunCommand",
+          "commentsCount",
+          "commitDetails",
+          "dominoStats",
+          "statuses",
+          "dependentRepositories",
+          "dependentDatasetMounts",
+          "dependentProjects",
+          "suggestDatasets",
+          "goalIds",
+          "dependentExternalVolumeMounts",
+          "snapshotDatasetsOnCompletion"
+        ]
+      },
+      "domino.jobs.interface.CommitDetails": {
+        "properties": {
+          "inputCommitId": { "type": "string" },
+          "outputCommitId": { "nullable": true, "type": "string" }
+        },
+        "required": ["inputCommitId"]
+      },
+      "domino.jobs.interface.ComputeClusterConfigSpecDto": {
+        "properties": {
+          "clusterType": { "$ref": "#/components/schemas/ComputeClusterType" },
+          "computeEnvironmentId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "computeEnvironmentRevisionSpec": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "enum": ["ActiveRevision", "LatestRevision"],
+                "type": "string"
+              },
+              {
+                "properties": { "revisionId": { "type": "string" } },
+                "required": ["revisionId"],
+                "type": "object"
+              }
+            ]
+          },
+          "extraConfigs": {
+            "additionalProperties": { "type": "string" },
+            "nullable": true,
+            "type": "object"
+          },
+          "masterHardwareTierId": {
+            "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierIdentifier",
+            "nullable": true
+          },
+          "maxWorkerCount": {
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "workerCount": { "format": "int32", "type": "integer" },
+          "workerHardwareTierId": {
+            "$ref": "#/components/schemas/domino.hardwaretier.api.HardwareTierIdentifier"
+          },
+          "workerStorage": {
+            "$ref": "#/components/schemas/Information",
+            "nullable": true
+          }
+        },
+        "required": [
+          "clusterType",
+          "computeEnvironmentId",
+          "workerCount",
+          "workerHardwareTierId"
+        ]
+      },
+      "domino.jobs.interface.DependentDatasetMount": {
+        "properties": {
+          "containerPath": { "nullable": true, "type": "string" },
+          "datasetId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "datasetName": { "type": "string" },
+          "isInput": { "type": "boolean" },
+          "projectId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "snapshotId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "snapshotVersion": {
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "required": ["datasetId", "datasetName", "projectId", "isInput"]
+      },
+      "domino.jobs.interface.DependentExternalVolumeMount": {
+        "properties": {
+          "mount": {
+            "$ref": "#/components/schemas/domino.jobs.interface.VolumeMount"
+          },
+          "name": { "type": "string" }
+        },
+        "required": ["name", "mount"]
+      },
+      "domino.jobs.interface.DependentProject": {
+        "properties": {
+          "commitId": { "type": "string" },
+          "projectId": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+        },
+        "required": ["projectId", "commitId"]
+      },
+      "domino.jobs.interface.DependentRepository": {
+        "properties": {
+          "finishedBranch": { "nullable": true, "type": "string" },
+          "finishedCommitId": { "nullable": true, "type": "string" },
+          "finishedCommitUri": { "nullable": true, "type": "string" },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "name": { "type": "string" },
+          "ref": { "type": "string" },
+          "serviceProvider": { "type": "string" },
+          "startingBranch": { "nullable": true, "type": "string" },
+          "startingCommitId": { "nullable": true, "type": "string" },
+          "startingCommitUri": { "nullable": true, "type": "string" },
+          "uri": { "type": "string" }
+        },
+        "required": ["id", "name", "uri", "ref", "serviceProvider"]
+      },
+      "domino.jobs.interface.DominoStats": {
+        "properties": {
+          "name": { "type": "string" },
+          "value": { "type": "string" }
+        },
+        "required": ["name", "value"]
+      },
+      "domino.projects.api.repositories.ReferenceDTO": {
+        "properties": {
+          "type": { "type": "string" },
+          "value": { "nullable": true, "type": "string" }
+        },
+        "required": ["type"]
+      },
+      "domino.jobs.interface.QueuedJobHistoryDetails": {
+        "properties": {
+          "expectedWait": { "type": "string" },
+          "explanation": { "type": "string" },
+          "helpText": { "type": "string" }
+        },
+        "required": ["expectedWait", "explanation", "helpText"]
+      },
+      "domino.jobs.interface.StageTime": {
+        "properties": {
+          "completedTime": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "runStartTime": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "submissionTime": { "format": "int64", "type": "integer" }
+        },
+        "required": ["submissionTime"]
+      },
+      "domino.jobs.interface.JobStartedBy": {
+        "properties": {
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "username": { "type": "string" }
+        },
+        "required": ["id", "username"]
+      },
+      "domino.jobs.interface.JobStatuses": {
+        "properties": {
+          "executionStatus": { "type": "string" },
+          "isArchived": { "type": "boolean" },
+          "isCompleted": { "type": "boolean" },
+          "isScheduled": { "type": "boolean" }
+        },
+        "required": [
+          "isCompleted",
+          "isArchived",
+          "isScheduled",
+          "executionStatus"
+        ]
+      },
+      "domino.jobs.interface.TagApplication": {
+        "properties": {
+          "createdAt": { "format": "int64", "type": "integer" },
+          "createdBy": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "name": { "type": "string" },
+          "projectId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "tagId": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+        },
+        "required": ["tagId", "name", "createdBy", "createdAt", "projectId"]
+      },
+      "domino.jobs.interface.JobUsageInJob": {
+        "properties": {
+          "cpu": { "format": "double", "type": "number" },
+          "memory": { "format": "double", "type": "number" }
+        },
+        "required": ["cpu", "memory"]
+      },
+      "domino.jobs.interface.WorkflowDetails": {
+        "properties": {
+          "executionMetadata": {
+            "$ref": "#/components/schemas/domino.jobs.interface.OrchestratorExecutionMetadata",
+            "nullable": true
+          },
+          "workflowOrchestrator": { "type": "string" }
+        },
+        "required": ["workflowOrchestrator"]
+      },
+      "domino.jobs.interface.LogsWithProblemSuggestion": {
+        "properties": {
+          "logset": {
+            "$ref": "#/components/schemas/domino.jobs.interface.LogSet"
+          },
+          "problemSuggestion": {
+            "$ref": "#/components/schemas/domino.jobs.interface.JobProblemSuggestion",
+            "nullable": true
+          }
+        },
+        "required": ["logset"]
+      },
+      "ComputeClusterType": {
+        "description": "Type of compute cluster",
+        "enum": ["Spark", "Ray", "Dask", "MPI"],
+        "type": "string"
+      },
+      "domino.hardwaretier.api.HardwareTierIdentifier": {
+        "properties": { "value": { "type": "string" } },
+        "required": ["value"]
+      },
+      "Information": {
+        "properties": {
+          "unit": { "$ref": "#/components/schemas/StorageUnit" },
+          "value": { "description": "Number being stored", "type": "number" }
+        },
+        "required": ["value", "unit"],
+        "type": "object"
+      },
+      "domino.jobs.interface.VolumeMount": {
+        "properties": {
+          "mountPath": { "type": "string" },
+          "readOnly": { "type": "boolean" },
+          "subPath": { "nullable": true, "type": "string" }
+        },
+        "required": ["mountPath", "readOnly"]
+      },
+      "domino.jobs.interface.OrchestratorExecutionMetadata": {
+        "properties": {
+          "nodeDomain": { "nullable": true, "type": "string" },
+          "nodeId": { "nullable": true, "type": "string" },
+          "nodeProjectId": { "nullable": true, "type": "string" },
+          "nodeWorkflowExecutionName": { "nullable": true, "type": "string" },
+          "taskDomain": { "nullable": true, "type": "string" },
+          "taskExecutionName": { "nullable": true, "type": "string" },
+          "taskExecutionVersion": { "nullable": true, "type": "string" },
+          "taskProjectId": { "nullable": true, "type": "string" }
+        }
+      },
+      "domino.jobs.interface.LogSet": {
+        "properties": {
+          "isComplete": { "type": "boolean" },
+          "logContent": {
+            "items": {
+              "$ref": "#/components/schemas/domino.jobs.interface.LogContent"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/domino.jobs.interface.PaginationFilter"
+          }
+        },
+        "required": ["logContent", "isComplete", "pagination"]
+      },
+      "domino.jobs.interface.JobProblemSuggestion": {
+        "properties": {
+          "helpLink": { "type": "string" },
+          "problem": { "type": "string" }
+        },
+        "required": ["problem", "helpLink"]
+      },
+      "domino.jobs.web.UpdateJobName": {
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"]
+      },
+      "StorageUnit": {
+        "description": "Unit of number being stored",
+        "enum": [
+          "B",
+          "o",
+          "KB",
+          "KiB",
+          "MB",
+          "MiB",
+          "GB",
+          "GiB",
+          "TB",
+          "TiB",
+          "PB",
+          "PiB",
+          "EB",
+          "EiB",
+          "ZB",
+          "ZiB",
+          "YB",
+          "YiB",
+          "bit",
+          "Kbit",
+          "Kibit",
+          "Mbit",
+          "Mibit",
+          "Gbit",
+          "Gibit",
+          "Tbit",
+          "Tibit",
+          "Pbit",
+          "Pibit",
+          "Ebit",
+          "Eibit",
+          "Zbit",
+          "Zibit",
+          "Ybit",
+          "Yibit"
+        ],
+        "type": "string"
+      },
+      "domino.jobs.interface.LogContent": {
+        "properties": {
+          "log": { "type": "string" },
+          "logType": {
+            "enum": ["stdout", "stderr", "prepareoutput", "complete"],
+            "type": "string"
+          },
+          "size": { "format": "int64", "type": "integer" },
+          "timestamp": { "format": "int64", "type": "integer" }
+        },
+        "required": ["timestamp", "logType", "log", "size"]
+      },
+      "domino.jobs.interface.PaginationFilter": {
+        "properties": {
+          "latestTimeNano": { "nullable": true, "type": "string" },
+          "limit": { "format": "int32", "type": "integer" },
+          "offset": { "format": "int32", "type": "integer" }
+        },
+        "required": ["limit", "offset"]
+      },
+      "domino.jobs.web.JobRestartOperationRequest": {
+        "properties": {
+          "jobId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "shouldUseOriginalInputCommit": { "type": "boolean" }
+        },
+        "required": ["jobId", "shouldUseOriginalInputCommit"]
+      },
+      "domino.jobs.web.StartJobRequest": {
+        "properties": {
+          "commandToRun": { "type": "string" },
+          "commitId": { "nullable": true, "type": "string" },
+          "computeClusterProperties": {
+            "$ref": "#/components/schemas/domino.jobs.interface.ComputeClusterConfigSpecDto",
+            "nullable": true
+          },
+          "environmentId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "environmentRevisionSpec": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "enum": ["ActiveRevision", "LatestRevision"],
+                "type": "string"
+              },
+              {
+                "properties": { "revisionId": { "type": "string" } },
+                "required": ["revisionId"],
+                "type": "object"
+              }
+            ]
+          },
+          "externalVolumeMounts": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "nullable": true,
+            "type": "array"
+          },
+          "mainRepoGitRef": {
+            "$ref": "#/components/schemas/domino.projects.api.repositories.ReferenceDTO",
+            "nullable": true
+          },
+          "onDemandSparkClusterProperties": {
+            "$ref": "#/components/schemas/domino.projects.api.OnDemandSparkClusterPropertiesSpec",
+            "nullable": true
+          },
+          "overrideHardwareTierId": { "nullable": true, "type": "string" },
+          "overrideVolumeSizeGiB": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "projectId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "snapshotDatasetsOnCompletion": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "title": { "nullable": true, "type": "string" }
+        },
+        "required": ["projectId", "commandToRun"]
+      },
+      "domino.projects.api.OnDemandSparkClusterPropertiesSpec": {
+        "properties": {
+          "computeEnvironmentId": {
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "computeEnvironmentRevisionSpec": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "enum": ["ActiveRevision", "LatestRevision"],
+                "type": "string"
+              },
+              {
+                "properties": { "revisionId": { "type": "string" } },
+                "required": ["revisionId"],
+                "type": "object"
+              }
+            ]
+          },
+          "executorCount": { "format": "int32", "type": "integer" },
+          "executorHardwareTierId": { "type": "string" },
+          "executorStorage": {
+            "$ref": "#/components/schemas/Information",
+            "nullable": true
+          },
+          "masterHardwareTierId": { "type": "string" }
+        },
+        "required": [
+          "computeEnvironmentId",
+          "executorCount",
+          "executorHardwareTierId",
+          "masterHardwareTierId"
+        ]
+      },
+      "domino.jobs.web.JobStopOperationRequest": {
+        "properties": {
+          "commitResults": { "type": "boolean" },
+          "jobId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "source": { "nullable": true, "type": "string" }
+        },
+        "required": ["jobId", "commitResults"]
+      },
+      "domino.projectManagement.web.LinkJobToGoalRequest": {
+        "properties": {
+          "goalId": { "pattern": "^[0-9a-f]{24}$", "type": "string" }
+        },
+        "required": ["goalId"]
+      },
+      "domino.projectManagement.api.ResponseMessage": {
+        "properties": { "message": { "type": "string" } },
+        "required": ["message"]
+      },
+      "domino.projectManagement.web.FilterProjectGoals": {
+        "properties": {
+          "assigneeIds": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "nullable": true,
+            "type": "array"
+          },
+          "stageIds": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "nullable": true,
+            "type": "array"
+          }
+        }
+      },
+      "domino.projects.api.ProjectGoal": {
+        "properties": {
+          "assigneeId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "createdAt": { "format": "int64", "type": "integer" },
+          "createdBy": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "currentStage": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectStage"
+          },
+          "description": { "nullable": true, "type": "string" },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "isComplete": { "type": "boolean" },
+          "isDeleted": { "type": "boolean" },
+          "lastDescriptionUpdatedAt": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "lastTitleUpdatedAt": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "lastUpdatedAt": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "linkedEntities": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.EntityLink"
+            },
+            "type": "array"
+          },
+          "projectId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "title": { "type": "string" }
+        },
+        "required": [
+          "id",
+          "title",
+          "linkedEntities",
+          "currentStage",
+          "isComplete",
+          "isDeleted",
+          "projectId",
+          "createdAt",
+          "createdBy"
+        ]
+      },
+      "domino.projects.api.ProjectStage": {
+        "properties": {
+          "createdAt": { "format": "int64", "type": "integer" },
+          "createdBy": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "isArchived": { "type": "boolean" },
+          "stage": { "type": "string" },
+          "stageCreationSource": {
+            "enum": ["Domino", "Jira"],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "stage",
+          "createdAt",
+          "isArchived",
+          "stageCreationSource"
+        ]
+      },
+      "domino.projects.api.EntityLink": {
+        "properties": {
+          "createdBy": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "entityLinkType": {
+            "enum": ["job", "model_api", "workspace", "app", "file"],
+            "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/domino.projects.api.EntityLinkMetadata"
+          },
+          "timestamp": { "format": "int64", "type": "integer" }
+        },
+        "required": ["entityLinkType", "metadata", "timestamp", "createdBy"]
+      },
+      "domino.nucleus.project.models.NewProject": {
+        "properties": {
+          "billingTag": {
+            "$ref": "#/components/schemas/domino.projects.api.BillingTag",
+            "nullable": true
+          },
+          "collaborators": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.CollaboratorDTO"
+            },
+            "type": "array"
+          },
+          "description": { "type": "string" },
+          "isRestricted": { "nullable": true, "type": "boolean" },
+          "mainRepository": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectGitRepositoryTemp",
+            "nullable": true
+          },
+          "name": { "type": "string" },
+          "ownerId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "repoToCreate": {
+            "$ref": "#/components/schemas/domino.projects.api.repositories.requests.CreateRepoRequest",
+            "nullable": true
+          },
+          "tags": {
+            "$ref": "#/components/schemas/domino.projects.api.NewTagsDTO"
+          },
+          "templateDetails": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateDetails",
+            "nullable": true
+          },
+          "visibility": {
+            "enum": ["Public", "Searchable", "Private"],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "visibility",
+          "ownerId",
+          "collaborators",
+          "tags"
+        ]
+      },
+      "domino.nucleus.project.models.Project": {
+        "properties": {
+          "billingTag": {
+            "$ref": "#/components/schemas/domino.projects.api.BillingTag",
+            "nullable": true
+          },
+          "collaboratorIds": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "type": "array"
+          },
+          "collaborators": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.CollaboratorDTO"
+            },
+            "type": "array"
+          },
+          "description": { "type": "string" },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "importedGitRepos": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.repositories.GitRepositoryDTO"
+            },
+            "type": "array"
+          },
+          "mainRepository": {
+            "$ref": "#/components/schemas/domino.server.projects.domain.entities.ProjectGitRepository",
+            "nullable": true
+          },
+          "name": { "type": "string" },
+          "ownerId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "ownerUsername": { "type": "string" },
+          "stageId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "status": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectStatus"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.ProjectTagDTO"
+            },
+            "type": "array"
+          },
+          "templateDetails": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateDetails",
+            "nullable": true
+          },
+          "visibility": { "type": "string" }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "visibility",
+          "ownerId",
+          "ownerUsername",
+          "importedGitRepos",
+          "collaboratorIds",
+          "collaborators",
+          "tags",
+          "stageId",
+          "status"
+        ]
+      },
+      "domino.projects.api.EntityLinkMetadata": { "properties": {} },
+      "domino.projects.api.BillingTag": {
+        "properties": { "tag": { "type": "string" } },
+        "required": ["tag"]
+      },
+      "domino.projects.api.CollaboratorDTO": {
+        "properties": {
+          "collaboratorId": { "type": "string" },
+          "projectRole": {
+            "enum": [
+              "ProjectImporter",
+              "Contributor",
+              "ResultsConsumer",
+              "LauncherUser",
+              "Owner"
+            ],
+            "type": "string"
+          }
+        },
+        "required": ["collaboratorId", "projectRole"]
+      },
+      "domino.projects.api.ProjectGitRepositoryTemp": {
+        "properties": {
+          "credentialId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "defaultRef": {
+            "$ref": "#/components/schemas/domino.projects.api.repositories.ReferenceDTO"
+          },
+          "id": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "name": { "nullable": true, "type": "string" },
+          "serviceProvider": { "type": "string" },
+          "uri": { "type": "string" }
+        },
+        "required": ["uri", "defaultRef", "serviceProvider"]
+      },
+      "domino.projects.api.repositories.requests.CreateRepoRequest": {
+        "properties": {
+          "credentialId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "owner": { "type": "string" },
+          "repositoryTemplateName": { "nullable": true, "type": "string" },
+          "repositoryToCreateName": { "type": "string" },
+          "serviceProvider": {
+            "enum": [
+              "github",
+              "gitlab",
+              "githubEnterprise",
+              "unknown",
+              "gitlabEnterprise",
+              "bitbucket",
+              "bitbucketServer"
+            ],
+            "type": "string"
+          },
+          "visibility": {
+            "enum": ["Public", "Private", "Internal"],
+            "type": "string"
+          }
+        },
+        "required": [
+          "serviceProvider",
+          "credentialId",
+          "repositoryToCreateName",
+          "owner",
+          "visibility"
+        ]
+      },
+      "domino.projects.api.NewTagsDTO": {
+        "properties": {
+          "tagNames": { "items": { "type": "string" }, "type": "array" }
+        },
+        "required": ["tagNames"]
+      },
+      "domino.projects.api.repositories.GitRepositoryDTO": {
+        "properties": {
+          "credentialId": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "id": {
+            "nullable": true,
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "isFeatureStore": { "nullable": true, "type": "boolean" },
+          "name": { "nullable": true, "type": "string" },
+          "ref": {
+            "$ref": "#/components/schemas/domino.projects.api.repositories.ReferenceDTO"
+          },
+          "serviceProvider": { "type": "string" },
+          "uri": { "type": "string" }
+        },
+        "required": ["uri", "ref", "serviceProvider"]
+      },
+      "domino.server.projects.domain.entities.ProjectGitRepository": {
+        "properties": {
+          "defaultRef": {
+            "$ref": "#/components/schemas/domino.projects.api.repositories.ReferenceDTO"
+          },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "name": { "nullable": true, "type": "string" },
+          "serviceProvider": {
+            "enum": [
+              "github",
+              "gitlab",
+              "githubEnterprise",
+              "unknown",
+              "gitlabEnterprise",
+              "bitbucket",
+              "bitbucketServer"
+            ],
+            "type": "string"
+          },
+          "uriHost": { "type": "string" },
+          "uriPath": { "type": "string" },
+          "uriPort": { "nullable": true, "type": "string" }
+        },
+        "required": [
+          "id",
+          "uriHost",
+          "uriPath",
+          "defaultRef",
+          "serviceProvider"
+        ]
+      },
+      "domino.projects.api.ProjectStatus": {
+        "properties": {
+          "blockedReason": { "nullable": true, "type": "string" },
+          "completedMessage": { "nullable": true, "type": "string" },
+          "isBlocked": { "type": "boolean" },
+          "status": { "enum": ["active", "complete"], "type": "string" }
+        },
+        "required": ["status", "isBlocked"]
+      },
+      "domino.projects.api.ProjectTagDTO": {
+        "properties": {
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "isApproved": { "type": "boolean" },
+          "name": { "type": "string" }
+        },
+        "required": ["id", "name", "isApproved"]
+      },
+      "domino.projects.api.ProjectSummary": {
+        "properties": {
+          "billingTag": {
+            "$ref": "#/components/schemas/domino.projects.api.BillingTag",
+            "nullable": true
+          },
+          "collaboratorIds": {
+            "items": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+            "type": "array"
+          },
+          "collaborators": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.CollaboratorDTO"
+            },
+            "type": "array"
+          },
+          "created": { "format": "date-time", "type": "string" },
+          "description": { "type": "string" },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "importedGitRepositories": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.repositories.GitRepositoryDTO"
+            },
+            "type": "array"
+          },
+          "internalTags": {
+            "items": { "type": "string" },
+            "nullable": true,
+            "type": "array"
+          },
+          "mainRepository": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectGitRepositoryTemp",
+            "nullable": true
+          },
+          "name": { "type": "string" },
+          "ownerId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "ownerUsername": { "type": "string" },
+          "stageId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "status": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectStatus"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/domino.projects.api.ProjectTagDTO"
+            },
+            "type": "array"
+          },
+          "templateDetails": {
+            "$ref": "#/components/schemas/domino.projects.api.ProjectTemplateDetails",
+            "nullable": true
+          },
+          "visibility": { "type": "string" }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "created",
+          "visibility",
+          "ownerId",
+          "ownerUsername",
+          "importedGitRepositories",
+          "collaboratorIds",
+          "collaborators",
+          "tags",
+          "stageId",
+          "status"
+        ]
+      },
+      "domino.nucleus.project.models.Collaborator": {
+        "properties": {
+          "collaboratorId": { "type": "string" },
+          "projectRole": {
+            "enum": [
+              "ProjectImporter",
+              "Contributor",
+              "ResultsConsumer",
+              "LauncherUser",
+              "Owner"
+            ],
+            "type": "string"
+          }
+        },
+        "required": ["collaboratorId", "projectRole"]
+      },
+      "domino.common.user.Person": {
+        "properties": {
+          "avatarUrl": {
+            "description": "Url of the person's avatar",
+            "type": "string"
+          },
+          "companyName": {
+            "description": "Person's company name",
+            "nullable": true,
+            "type": "string"
+          },
+          "email": {
+            "description": "Person email",
+            "nullable": true,
+            "type": "string"
+          },
+          "firstName": { "description": "Person first name", "type": "string" },
+          "fullName": { "description": "Person full name", "type": "string" },
+          "id": {
+            "description": "Person user id",
+            "pattern": "^[0-9a-f]{24}$",
+            "type": "string"
+          },
+          "idpId": { "nullable": true, "type": "string" },
+          "lastName": { "description": "Person last name", "type": "string" },
+          "phoneNumber": {
+            "description": "Person phone number",
+            "nullable": true,
+            "type": "string"
+          },
+          "userName": { "description": "Person username", "type": "string" }
+        },
+        "required": [
+          "firstName",
+          "lastName",
+          "fullName",
+          "userName",
+          "avatarUrl",
+          "id"
+        ],
+        "type": "object"
+      },
+      "domino.common.models.EnvironmentVariable": {
+        "properties": {
+          "name": { "type": "string" },
+          "value": { "type": "string" }
+        },
+        "required": ["name", "value"]
+      },
+      "domino.common.run.interfaces.RunMonolithDTO": {
+        "properties": {
+          "estimatedCost": { "format": "double", "type": "number" },
+          "hardwareTierName": { "type": "string" },
+          "id": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "projectId": { "pattern": "^[0-9a-f]{24}$", "type": "string" },
+          "projectIdentity": { "type": "string" },
+          "runDurationInSeconds": { "format": "double", "type": "number" },
+          "runType": { "type": "string" },
+          "startTime": { "type": "string" },
+          "status": {
+            "enum": [
+              "Pending",
+              "Stopping",
+              "Stopped",
+              "Scheduled",
+              "Pulling",
+              "Succeeded",
+              "StopAndDiscardRequested",
+              "Building",
+              "Error",
+              "Finishing",
+              "Queued",
+              "StopRequested",
+              "Preparing",
+              "Running",
+              "Failed",
+              "Serving"
+            ],
+            "type": "string"
+          },
+          "title": { "type": "string" }
+        },
+        "required": [
+          "id",
+          "title",
+          "startTime",
+          "projectId",
+          "projectIdentity",
+          "runType",
+          "hardwareTierName",
+          "runDurationInSeconds",
+          "estimatedCost",
+          "status"
+        ]
+      },
+      "domino.scheduledjob.api.LegacyScheduledRunDTO": {
+        "properties": {
+          "emailsToNotify": { "nullable": true, "type": "string" },
+          "hardwareTierName": { "type": "string" },
+          "id": { "type": "string" },
+          "launchBehavior": {
+            "enum": ["Concurrent", "Sequential"],
+            "type": "string"
+          },
+          "projectIdentity": { "type": "string" },
+          "scheduleTime": { "type": "string" },
+          "schedulingUserName": { "type": "string" },
+          "title": { "nullable": true, "type": "string" }
+        },
+        "required": [
+          "id",
+          "schedulingUserName",
+          "scheduleTime",
+          "hardwareTierName",
+          "launchBehavior",
+          "projectIdentity"
+        ]
+      },
+      "domino.common.user.CreateUserRequest": {
+        "properties": {
+          "email": { "type": "string" },
+          "roles": { "items": { "type": "string" }, "type": "array" }
+        },
+        "required": ["email", "roles"]
+      },
+      "domino.common.models.EnvironmentVariables": {
+        "properties": {
+          "vars": {
+            "items": {
+              "$ref": "#/components/schemas/domino.common.models.EnvironmentVariable"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["vars"]
+      }
+    },
+    "responses": {
+      "Forbidden": { "description": "Forbidden" },
+      "NotFound": { "description": "Not Found" },
+      "InternalError": { "description": "Internal Server Error" },
+      "BadRequest": {
+        "description": "Bad Request",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "ProjectManagementErrorResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/domino.projectManagement.web.ErrorResponse"
+            }
+          }
+        },
+        "description": "The current operation failed due to external service failure"
+      },
+
+      "Relogin": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "redirectPath": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "description": "User needs to re-login even if they are logged in and come back"
+      },
+      "Unauthorized": {
+        "description": "Unauthorized",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
         }
       }
     },
-    "security": [
-        {
-          "BearerAuthentication": []
-        },
-        {
-          "DominoApiKey": []
-        }
-      ],
-    "servers": [
-        {
-          "url": "/v4"
-        }
-      ],
-    "tags": []    
-  }
+    "securitySchemes": {
+      "BearerAuthentication": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey"
+      },
+      "DominoApiKey": {
+        "in": "header",
+        "name": "X-Domino-Api-Key",
+        "type": "apiKey"
+      }
+    }
+  },
+  "security": [{ "BearerAuthentication": [] }, { "DominoApiKey": [] }],
+  "servers": [{ "url": "/v4" }],
+  "tags": []
+}

--- a/src/conf/slim-api.json
+++ b/src/conf/slim-api.json
@@ -6,6 +6,334 @@
         "version": "4.0.0"
       },
     "paths": {
+
+      "/admin/supportbundle/{executionId}": {
+        "get": {
+          "operationId": "getExecutionSupportBundle",
+          "parameters": [
+            {
+              "in": "path",
+              "name": "executionId",
+              "required": true,
+              "schema": {
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "format": "binary",
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "success"
+            },
+            "400": {
+              "$ref": "#/components/responses/BadRequest"
+            },
+            "401": {
+              "$ref": "#/components/responses/Unauthorized"
+            },
+            "403": {
+              "$ref": "#/components/responses/Forbidden"
+            },
+            "500": {
+              "$ref": "#/components/responses/InternalError"
+            }
+          },
+          "summary": "Gets a zipfile containing useful information about an executionId, FIXME should this path be /executions/executionId/supportbundle",
+          "tags": [
+            "Admin"
+          ]
+        }
+      },
+      "/datasetrw/snapshot/{snapshotId}/download-local/{taskKey}": {
+        "get": {
+          "operationId": "downloadArchiveToLocal",
+          "parameters": [
+            {
+              "description": "Id of the dataset snapshot where files are downloaded from",
+              "in": "path",
+              "name": "snapshotId",
+              "required": true,
+              "schema": {
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string"
+              }
+            },
+            {
+              "description": "Key of the download task to be polled",
+              "in": "path",
+              "name": "taskKey",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "format": "binary",
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "success"
+            },
+            "400": {
+              "$ref": "#/components/responses/BadRequest"
+            },
+            "401": {
+              "$ref": "#/components/responses/Unauthorized"
+            },
+            "403": {
+              "$ref": "#/components/responses/Forbidden"
+            },
+            "500": {
+              "$ref": "#/components/responses/InternalError"
+            }
+          },
+          "summary": "Download archive file from Domino to local",
+          "tags": [
+            "DatasetRw"
+          ]
+        }
+      },      
+      "/datasetrw/snapshot/{snapshotId}/file/raw": {
+        "get": {
+          "operationId": "getFileRaw",
+          "parameters": [
+            {
+              "description": "snapshot ID",
+              "in": "path",
+              "name": "snapshotId",
+              "required": true,
+              "schema": {
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string"
+              }
+            },
+            {
+              "description": "path of file to get raw content for",
+              "in": "query",
+              "name": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            },
+            {
+              "description": "whether endpoint is used for download",
+              "in": "query",
+              "name": "download",
+              "required": false,
+              "schema": {
+                "nullable": true,
+                "type": "boolean"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "content": {
+                "application/octet-stream": {
+                  "schema": {
+                    "format": "binary",
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "success"
+            },
+            "400": {
+              "$ref": "#/components/responses/BadRequest"
+            },
+            "401": {
+              "$ref": "#/components/responses/Unauthorized"
+            },
+            "403": {
+              "$ref": "#/components/responses/Forbidden"
+            },
+            "500": {
+              "$ref": "#/components/responses/InternalError"
+            }
+          },
+          "summary": "Get snapshot file raw content at specified path",
+          "tags": [
+            "DatasetRw"
+          ]
+        }
+      },      
+      "/datasource/audit/download/runs": {
+        "get": {
+          "operationId": "downloadDataSourceAuditDataInRuns",
+          "parameters": [
+            {
+              "description": "the ids of the runs to query datasources from",
+              "in": "query",
+              "name": "runIds",
+              "required": true,
+              "schema": {
+                "items": {
+                  "pattern": "^[0-9a-f]{24}$",
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            {
+              "description": "if true output will be json file, else txt",
+              "in": "query",
+              "name": "jsonFile",
+              "required": false,
+              "schema": {
+                "nullable": true,
+                "type": "boolean"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "content": {
+                "application/jsonl": {
+                  "schema": {
+                    "format": "binary",
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "success"
+            },
+            "400": {
+              "$ref": "#/components/responses/BadRequest"
+            },
+            "401": {
+              "$ref": "#/components/responses/Unauthorized"
+            },
+            "403": {
+              "$ref": "#/components/responses/Forbidden"
+            },
+            "500": {
+              "$ref": "#/components/responses/InternalError"
+            }
+          },
+          "summary": "Download DataSource Audit Data accessed in Domino runs",
+          "tags": [
+            "DataSource"
+          ]
+        }
+      },
+      "/datasource/audit/download": {
+        "get": {
+          "operationId": "downloadDataSourceAuditData",
+          "parameters": [
+            {
+              "description": "if true output will be json file, else txt",
+              "in": "query",
+              "name": "jsonFile",
+              "required": false,
+              "schema": {
+                "nullable": true,
+                "type": "boolean"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "content": {
+                "application/octet-stream": {
+                  "schema": {
+                    "format": "binary",
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "success"
+            },
+            "400": {
+              "$ref": "#/components/responses/BadRequest"
+            },
+            "401": {
+              "$ref": "#/components/responses/Unauthorized"
+            },
+            "403": {
+              "$ref": "#/components/responses/Forbidden"
+            },
+            "500": {
+              "$ref": "#/components/responses/InternalError"
+            }
+          },
+          "summary": "Download DataSource Audit Data for past 6 months",
+          "tags": [
+            "DataSource"
+          ]
+        }
+      },      
+      "/modelManager/{modelVersionId}/logs": {
+        "get": {
+          "operationId": "downloadLogs",
+          "parameters": [
+            {
+              "in": "path",
+              "name": "modelVersionId",
+              "required": true,
+              "schema": {
+                "pattern": "^[0-9a-f]{24}$",
+                "type": "string"
+              }
+            },
+            {
+              "in": "query",
+              "name": "startMillis",
+              "required": true,
+              "schema": {
+                "format": "int64",
+                "type": "integer"
+              }
+            },
+            {
+              "in": "query",
+              "name": "endMillis",
+              "required": true,
+              "schema": {
+                "format": "int64",
+                "type": "integer"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "content": {
+                "application/x-ndjson": {
+                  "schema": {
+                    "format": "binary",
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "success"
+            },
+            "401": {
+              "$ref": "#/components/responses/Unauthorized"
+            },
+            "500": {
+              "$ref": "#/components/responses/InternalError"
+            }
+          },
+          "summary": "download logs for a model for a given time range",
+          "tags": [
+            "ModelManager"
+          ]
+        }
+      },      
       "/projects/{projectId}/useableEnvironments": {
         "get": {
           "operationId": "getUseableEnvironments",
@@ -47,7 +375,7 @@
             "Projects"
           ]
         }
-      }
+      }      
     },
     "components": {
       "schemas": {
@@ -75,6 +403,14 @@
               "type": "string"
             }
           }
+        },
+        "Error": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string"
+            }
+          }
         }
       },
       "responses": {
@@ -86,6 +422,26 @@
         },
         "InternalError": {
           "description": "Internal Server Error"
+        },
+        "BadRequest": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "Unauthorized": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
         }
       },
       "securitySchemes": {


### PR DESCRIPTION
## Overview

- Adds `slim-api.json` which is a subset of the Domino v4 internal API currently used by KSM.
- Replaces `domino-openapi.json` in build step with `slim-api.json`

### Source data
[domino-internal-api-usage.csv](https://github.com/user-attachments/files/17194908/domino-internal-api-usage.csv)

