### PR TITLE
Remove projectsDependencyGraph from internal spec

### DIFF
--- a/src/conf/domino-internal-api-usage.csv
+++ b/src/conf/domino-internal-api-usage.csv
@@ -30,7 +30,6 @@ delete,/v4,/datasource/{dataSourceId}/projects/{projectId}
 post,/v4,/datasource/{dataSourceId}/projects/{projectId}
 get,/v4,/gateway/projects
 get,/v4,/gateway/projects/findProjectByOwnerAndName
-get,/v4,/gateway/users/projectsDependencyGraph
 get,/v4,/jobs/{jobId}
 get,/v4,/jobs/{jobId}/logsWithProblemSuggestions
 post,/v4,/jobs/{jobId}/name

--- a/src/conf/slim-api.json
+++ b/src/conf/slim-api.json
@@ -154,20 +154,6 @@
         },
         "type": "object"
       },
-      "domino.common.ProjectId": {
-        "properties": {
-          "ownerUsername": {
-            "type": "string"
-          },
-          "projectName": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "ownerUsername",
-          "projectName"
-        ]
-      },
       "domino.common.models.EnvironmentVariable": {
         "properties": {
           "name": {
@@ -2922,49 +2908,6 @@
         },
         "required": [
           "name"
-        ]
-      },
-      "domino.nucleus.gateway.users.models.ProjectDependencyView": {
-        "properties": {
-          "dependencies": {
-            "items": {
-              "$ref": "#/components/schemas/domino.common.ProjectId"
-            },
-            "type": "array"
-          },
-          "projectId": {
-            "$ref": "#/components/schemas/domino.common.ProjectId"
-          },
-          "projectType": {
-            "enum": [
-              "Analytic",
-              "DataSet",
-              "Template"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "projectId",
-          "projectType",
-          "dependencies"
-        ]
-      },
-      "domino.nucleus.gateway.users.models.ProjectsDependencyGraph": {
-        "properties": {
-          "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/domino.nucleus.gateway.users.models.ProjectDependencyView"
-            },
-            "type": "array"
-          },
-          "selectedProjectId": {
-            "$ref": "#/components/schemas/domino.common.ProjectId",
-            "nullable": true
-          }
-        },
-        "required": [
-          "nodes"
         ]
       },
       "domino.nucleus.project.models.Collaborator": {
@@ -6314,56 +6257,6 @@
         "summary": "Retrieves a project for the Project Overview UI",
         "tags": [
           "Gateway"
-        ]
-      }
-    },
-    "/gateway/users/projectsDependencyGraph": {
-      "get": {
-        "operationId": "projectsDependencyGraph",
-        "parameters": [
-          {
-            "description": "Owner username of the project, if dependency graph is being requested for a specific project.",
-            "in": "query",
-            "name": "ownerUsername",
-            "required": false,
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            }
-          },
-          {
-            "description": "Project name for which a dependency graph is being requested. When not provided, the dependency graph is for all projects for the current user.",
-            "in": "query",
-            "name": "projectName",
-            "required": false,
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/domino.nucleus.gateway.users.models.ProjectsDependencyGraph"
-                }
-              }
-            },
-            "description": "success"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "500": {
-            "$ref": "#/components/responses/InternalError"
-          }
-        },
-        "summary": "Retrieves projects dependency graph for a user, and optionally for a specific project",
-        "tags": [
-          "Gateway",
-          "Users"
         ]
       }
     },

--- a/src/test/java/com/dominodatalab/api/rest/GatewayApiTest.java
+++ b/src/test/java/com/dominodatalab/api/rest/GatewayApiTest.java
@@ -15,9 +15,6 @@ import com.dominodatalab.TestClientConfigurer;
 import com.dominodatalab.TestData;
 import com.dominodatalab.api.invoker.ApiClient;
 import com.dominodatalab.api.invoker.ApiException;
-import com.dominodatalab.api.model.DominoCommonProjectId;
-import com.dominodatalab.api.model.DominoNucleusGatewayUsersModelsProjectDependencyView;
-import com.dominodatalab.api.model.DominoNucleusGatewayUsersModelsProjectsDependencyGraph;
 import com.dominodatalab.api.model.DominoServerProjectsApiProjectGatewayOverview;
 import com.dominodatalab.api.model.DominoServerProjectsApiProjectGatewaySummary;
 

--- a/src/test/java/com/dominodatalab/api/rest/GatewayApiTest.java
+++ b/src/test/java/com/dominodatalab/api/rest/GatewayApiTest.java
@@ -89,49 +89,5 @@ class GatewayApiTest extends TestClientConfigurer {
         assertEquals(500, th.getCode());
         assert(th.getMessage()).contains("No value found for '" + relationship + "'");
     }
-
-    @Test
-    void projectsDependencyGraphSuccess() throws ApiException {
-        // Arrange
-        String ownerName = getUserName();
-        String projectName = "quick-start";
-
-        // Act
-        DominoNucleusGatewayUsersModelsProjectsDependencyGraph graph = gatewayApi.projectsDependencyGraph(ownerName, projectName);
-
-        // Assert
-        DominoCommonProjectId projectId = graph.getSelectedProjectId();
-        assertNotNull(projectId);
-        assertEquals(ownerName, projectId.getOwnerUsername());
-        assertEquals(projectName, projectId.getProjectName());
-
-        assertNotNull(graph.getNodes());
-        List<DominoNucleusGatewayUsersModelsProjectDependencyView> nodes = graph.getNodes();
-        assertEquals(1, nodes.size());
-
-        DominoNucleusGatewayUsersModelsProjectDependencyView primary = nodes.get(0);
-        assertEquals(ownerName, primary.getProjectId().getOwnerUsername());
-        assertEquals(projectName, primary.getProjectId().getProjectName());
-        assertTrue(primary.getDependencies().isEmpty());
-    }
-
-    @Test
-    void projectsDependencyGraphNotFound() throws ApiException {
-        // Arrange
-        String ownerName = getUserName();
-        String projectName = "project-does-not-exist";
-
-        // Act
-        DominoNucleusGatewayUsersModelsProjectsDependencyGraph graph = gatewayApi.projectsDependencyGraph(ownerName, projectName);
-
-        // Assert
-        DominoCommonProjectId projectId = graph.getSelectedProjectId();
-        assertNotNull(projectId);
-        assertEquals(ownerName, projectId.getOwnerUsername());
-        assertEquals(projectName, projectId.getProjectName());
-
-        assertNotNull(graph.getNodes());
-        assertEquals(0, graph.getNodes().size());
-    }
     
 }


### PR DESCRIPTION
The `GatewayApi.projectsDependencyGraph` was originally used in the Domino CLI as a command but was removed due to incompatibility with prior code when updating the spec. This command was not used in any of our scripts or tested until ported over for the Java client testing. Since it is not used downstream anywhere I am opting to remove it from the spec to reduce potential burden later.