### PR TITLE
Use int64 for NetApp Volume capacity fields

### DIFF
--- a/src/conf/domino-netapp-api.json
+++ b/src/conf/domino-netapp-api.json
@@ -544,7 +544,8 @@
       "properties": {
         "capacity": {
           "description": "Maximum size in bytes",
-          "type": "integer"
+          "type": "integer",
+          "format": "int64"
         },
         "createdAt": {
           "type": "string"
@@ -600,7 +601,8 @@
         },
         "storageSize": {
           "description": "Used size in bytes",
-          "type": "integer"
+          "type": "integer",
+          "format": "int64"
         },
         "uniqueName": {
           "type": "string"
@@ -900,7 +902,8 @@
     "server.CreateVolumeRequest": {
       "properties": {
         "capacity": {
-          "type": "integer"
+          "type": "integer",
+          "format": "int64"
         },
         "description": {
           "type": "string"


### PR DESCRIPTION
Updates capacity-related fields of NetApp Volume DTOs to use `int64/long` integer format to avoid out-of-bounds errors when deserializing JSON responses.