### PR TITLE
Fix response type for Volume Grants

### DIFF
--- a/src/conf/domino-netapp-api.json
+++ b/src/conf/domino-netapp-api.json
@@ -3777,7 +3777,10 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/remotefs.VolumeGrant"
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/remotefs.VolumeGrant"
+              }
             }
           },
           "400": {


### PR DESCRIPTION
`PUT /volumes/{id}/grants` endpoint accepts and returns a List of `RemoteFSVolumeGrant`. However the OpenAPI spec from Domino is incorrect stating a single grant object is returned. This leads to JSON de-serialization errors at runtime. This PR fixes the response definition in the OpenAPI file.